### PR TITLE
Cleaner link handling

### DIFF
--- a/enderchest/cli.py
+++ b/enderchest/cli.py
@@ -1,6 +1,7 @@
 """Command-line interface"""
 import argparse
 import os
+from functools import partial
 from pathlib import Path
 from typing import Callable
 
@@ -47,8 +48,23 @@ def parse_args(argv=None) -> tuple[_Action, Path]:
         type=str,
         default=os.getcwd(),
     )
+    parser.add_argument(
+        "-k",
+        "--keep-broken",
+        action="store_true",
+        help="do not remove broken links when performing place",
+    )
     args = parser.parse_args(argv)
-    return actions[args.action], Path(args.root)
+
+    action = actions[args.action]
+    if args.keep_broken:
+        if args.action != "place":
+            raise ValueError(
+                "--keep-broken flag is only valid when using the place command"
+            )
+        action = partial(action, cleanup=False)
+
+    return action, Path(args.root)
 
 
 def main():

--- a/enderchest/place.py
+++ b/enderchest/place.py
@@ -5,13 +5,16 @@ from pathlib import Path
 from . import contexts
 
 
-def place_enderchest(root: str | os.PathLike) -> None:
+def place_enderchest(root: str | os.PathLike, cleanup: bool = True) -> None:
     """Link all instance files and folders
 
     Parameters
     ----------
     root : path
         The root directory that contains both the EnderChest directory, instances and servers
+    cleanup : bool, optional
+        By default, this method will remove any broken links in your instances and servers folders.
+        To disable this behavior, pass in cleanup=False
     """
     instances = Path(root) / "instances"
     servers = Path(root) / "servers"
@@ -27,8 +30,10 @@ def place_enderchest(root: str | os.PathLike) -> None:
                     link_instance(path, instances / tag, link)
                 # if make_server_links:
                 #     link_server(path, instances / tag, link)
-
-        # TODO: clean up broken links
+    if cleanup:
+        for file in (*instances.rglob("*"), *servers.rglob("*")):
+            if not file.exists():
+                file.unlink()
 
 
 def link_instance(resource_path: str, instance_folder: Path, destination: Path) -> None:

--- a/enderchest/place.py
+++ b/enderchest/place.py
@@ -55,8 +55,8 @@ def link_instance(resource_path: str, instance_folder: Path, destination: Path) 
     instance_file = instance_folder / ".minecraft" / resource_path
     instance_file.parent.mkdir(parents=True, exist_ok=True)
     relative_path = os.path.relpath(destination, instance_file.parent)
-    if instance_file.exists() and instance_file.is_symlink():
-        # it's okay to overwrite (our own) symlinks
+    if instance_file.is_symlink():
+        # remove previous symlink in this spot
         instance_file.unlink()
     os.symlink(relative_path, instance_file)
 

--- a/enderchest/place.py
+++ b/enderchest/place.py
@@ -28,6 +28,8 @@ def place_enderchest(root: str | os.PathLike) -> None:
                 # if make_server_links:
                 #     link_server(path, instances / tag, link)
 
+        # TODO: clean up broken links
+
 
 def link_instance(resource_path: str, instance_folder: Path, destination: Path) -> None:
     """Create a symlink for the specified resource from an instance's space pointing to the
@@ -53,6 +55,9 @@ def link_instance(resource_path: str, instance_folder: Path, destination: Path) 
     instance_file = instance_folder / ".minecraft" / resource_path
     instance_file.parent.mkdir(parents=True, exist_ok=True)
     relative_path = os.path.relpath(destination, instance_file.parent)
+    if instance_file.exists() and instance_file.is_symlink():
+        # it's okay to overwrite (our own) symlinks
+        instance_file.unlink()
     os.symlink(relative_path, instance_file)
 
 

--- a/enderchest/place.py
+++ b/enderchest/place.py
@@ -36,7 +36,9 @@ def place_enderchest(root: str | os.PathLike, cleanup: bool = True) -> None:
                 file.unlink()
 
 
-def link_instance(resource_path: str, instance_folder: Path, destination: Path) -> None:
+def link_instance(
+    resource_path: str, instance_folder: Path, destination: Path, check_exists=True
+) -> None:
     """Create a symlink for the specified resource from an instance's space pointing to the
     tagged file / folder living in the EnderChest folder.
 
@@ -48,6 +50,9 @@ def link_instance(resource_path: str, instance_folder: Path, destination: Path) 
         the instance's folder (parent of ".minecraft")
     destination : Path
         the location to link, where the file or older actually lives (inside the EnderChest folder)
+    check_exists : bool, optional
+        By default, this method will only create links if a ".minecraft" folder exists in the
+        instance_folder. To create links regardless, pass check_exists=False
 
     Returns
     -------
@@ -57,6 +62,9 @@ def link_instance(resource_path: str, instance_folder: Path, destination: Path) 
     -----
     This method will create any folders that do not existc
     """
+    if not (instance_folder / ".minecraft").exists() and check_exists:
+        return
+
     instance_file = instance_folder / ".minecraft" / resource_path
     instance_file.parent.mkdir(parents=True, exist_ok=True)
     relative_path = os.path.relpath(destination, instance_file.parent)


### PR DESCRIPTION
- Implements overwriting global links with client-only links with local-only links
- `enderchest place` now overwrites all existing links
- by default, `enderchest place` removes any broken links (which you'd get if you were, like, upgrading a mod)
- `enderchest place` won't place links for instances that don't already exist