### PR TITLE
Syncing between EnderChests

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -39,7 +39,7 @@ jobs:
       with:
         python-version: "3.10"
     - name: Setup Rsync
-      uses: GuillaumeFalourd/setup-rsync@v1
+      uses: GuillaumeFalourd/setup-rsync@v1.1
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -28,7 +28,10 @@ jobs:
       run: |
         mypy .
   test:
-    runs-on: [ubuntu-latest, windows-latest]  # TODO: bring back macos-latest
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.10

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,10 +7,28 @@ on:
   pull_request
 
 jobs:
-  build:
-
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest mypy black isort flake8 pytest-cov
+    - name: Run code quality checks
+      run: |
+        isort . --profile="black"
+        black .
+        flake8 .
+    - name: Type check with mypy
+      run: |
+        mypy .
+  test:
     runs-on: [ubuntu-latest, windows-latest, macos-latest]
-
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.10
@@ -23,12 +41,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pytest mypy black isort flake8 pytest-cov
-    - name: Run code quality checks
-      run: |
-        isort . --profile="black"
-        black .
-        mypy .
-        flake8 .
     - name: Run unit tests
       run: |
         pytest -vv --cov=enderchest
+      

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,7 +1,7 @@
 # Checks performed on all pull requests, to any branch. Thus, required for protected branches,
 # but enables a workflow for CI validation against non-protected branches as well.
 
-name: Python application
+name: PR checker
 
 on:
   pull_request
@@ -23,15 +23,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pytest mypy black isort flake8 pytest-cov
-    - name: Autolint as needed
+    - name: Run code quality checks
       run: |
         isort . --profile="black"
         black .
-        # if nothing has changed, this won't do anything
-        git add .
-        git commit -m "Emptying the lint trap"
-    - name: Run code quality checks
-      run: |
         mypy .
         flake8 .
     - name: Run unit tests

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,39 @@
+# Checks performed on all pull requests, to any branch. Thus, required for protected branches,
+# but enables a workflow for CI validation against non-protected branches as well.
+
+name: Python application
+
+on:
+  pull_request
+
+jobs:
+  build:
+
+    runs-on: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+    - name: Setup Rsync
+      uses: GuillaumeFalourd/setup-rsync@v1
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest mypy black isort flake8 pytest-cov
+    - name: Autolint as needed
+      run: |
+        isort . --profile="black"
+        black .
+        # if nothing has changed, this won't do anything
+        git add .
+        git commit -m "Emptying the lint trap"
+    - name: Run code quality checks
+      run: |
+        mypy .
+        flake8 .
+    - name: Run unit tests
+      run: |
+        pytest -vv --cov=enderchest

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -28,7 +28,7 @@ jobs:
       run: |
         mypy .
   test:
-    runs-on: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: [ubuntu-latest, windows-latest]  # TODO: bring back macos-latest
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.10

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
-
+enderchest/example_configs/*.cfg
+enderchest/example_configs/*.toml

--- a/enderchest/__init__.py
+++ b/enderchest/__init__.py
@@ -26,12 +26,15 @@ def contexts(root: str | os.PathLike) -> Contexts:
         - client-only : for syncing across all client instances
         - server-only : for syncing across all server instances
         - local-only : for local use only (don't sync)
-        - other-locals : "local-only" folders from other installations (for distributed backups)
+        - other-locals : "local-only" folders from other installations
+                         (for distributed backups)
 
     Notes
     -----
-    - Because "global" is a restricted keyword in Python, the namedtuple key for this context is "universal"
-    - For all other contexts, the namedtuple key replaces a dash (not a valid token character) with an underscore   `
+    - Because "global" is a restricted keyword in Python, the namedtuple key for
+      this context is "universal"
+    - For all other contexts, the namedtuple key replaces a dash (not a valid token
+      character) with an underscore   `
     """
     ender_chest = Path(root) / "EnderChest"
 

--- a/enderchest/__init__.py
+++ b/enderchest/__init__.py
@@ -10,8 +10,9 @@ __version__ = _version.get_versions()["version"]
 class Contexts(NamedTuple):
     universal: Path
     client_only: Path
-    local_only: Path
     server_only: Path
+    local_only: Path
+    other_locals: Path
 
 
 def contexts(root: str | os.PathLike) -> Contexts:
@@ -21,16 +22,23 @@ def contexts(root: str | os.PathLike) -> Contexts:
     -------
     Tuple of Paths
         The contexts, in order,
-        - global
-        - client-only
-        - local-only
-        - server-only
+        - global : for syncing across all instances and servers
+        - client-only : for syncing across all client instances
+        - server-only : for syncing across all server instances
+        - local-only : for local use only (don't sync)
+        - other-locals : "local-only" folders from other installations (for distributed backups)
+
+    Notes
+    -----
+    - Because "global" is a restricted keyword in Python, the namedtuple key for this context is "universal"
+    - For all other contexts, the namedtuple key replaces a dash (not a valid token character) with an underscore   `
     """
     ender_chest = Path(root) / "EnderChest"
 
     return Contexts(
         ender_chest / "global",
         ender_chest / "client-only",
-        ender_chest / "local-only",
         ender_chest / "server-only",
+        ender_chest / "local-only",
+        ender_chest / "other-locals",
     )

--- a/enderchest/cli.py
+++ b/enderchest/cli.py
@@ -1,7 +1,11 @@
 """Command-line interface"""
 import argparse
 import os
+import shlex
+import shutil
+import subprocess
 import sys
+from functools import partial
 from pathlib import Path
 from typing import Any, Protocol, Sequence
 
@@ -25,6 +29,19 @@ def _dispatch_craft(root: str | os.PathLike, **kwargs) -> None:
         craft_ender_chest(root, *remotes, **kwargs)
 
 
+def _dispatch_open_and_close(
+    root: str | os.PathLike, action: str, command_line_args: list[str]
+) -> None:
+    """Run the open / close script"""
+    if action == "open":
+        command = "./EnderChest/local-only/open.sh"
+    elif action == "close":
+        command = "./EnderChest/local-only/close.sh"
+    else:
+        raise ValueError(f"Unrecognized action {action}")
+    _run_bash(root, command, *command_line_args)
+
+
 ACTIONS: tuple[tuple[str, str, _Action], ...] = (
     # action name, action description, action method
     (
@@ -38,7 +55,86 @@ ACTIONS: tuple[tuple[str, str, _Action], ...] = (
         " instances and servers",
         place_enderchest,
     ),
+    (
+        "open",
+        "pull changes from other EnderChests",
+        partial(_dispatch_open_and_close, action="open"),
+    ),
+    (
+        "close",
+        "push changes to other EnderChests",
+        partial(_dispatch_open_and_close, action="close"),
+    ),
 )
+
+
+def _run_bash(
+    root: str | os.PathLike, *args: Any, **subproccess_kwargs
+) -> subprocess.CompletedProcess[str]:
+    """Run a bash command
+
+    Parameters
+    ----------
+    root : path-like
+        The working directory in which the command should be run
+    *args : Any
+        The command to run and any additional command-line flags to pass through
+    **subprocess_kwargs
+        Any keyword arguments to pass to subprocess.run
+
+    Returns
+    -------
+    None
+
+    Notes
+    -----
+    The commands will be executed in a subshell as the current user and should source
+    any `.bashrc` / `.bash_profile` files that would usually be sourced upon starting
+    a new shell
+
+    The intention of allowing subprocess kwargs and returning the process is that it
+    turns out this method is really useful for writing OS-agnostic CLI tests!
+    """
+    bash = shutil.which("bash")
+    if bash is None:
+        raise RuntimeError("This command requires bash to run. Please install bash.")
+
+    command = " ".join((shlex.quote(str(arg)) for arg in args))
+    return subprocess.run(
+        [bash, "-c", command],
+        cwd=Path(root).expanduser().resolve(),
+        **subproccess_kwargs,
+    )
+
+
+class PassThroughParser:
+    """Command-line argument parser that just collects any (non --help) flags
+    into a list of arguments"""
+
+    def __init__(self, **argparse_kwargs):
+        self._parser = argparse.ArgumentParser(**argparse_kwargs)
+
+    def add_argument(self, *args, **kwargs):
+        self._parser.add_argument(*args, **kwargs)
+
+    def parse_args(self, args) -> argparse.Namespace:
+        if "-h" in args or "--help" in args:
+            return self._parser.parse_args(["--help"])
+
+        arguments: dict[str, Any] = {}
+        root: Path | None = None
+        if len(args) > 0 and not args[0].startswith("-"):
+            try:
+                root = Path(args[0])
+                args = args[1:]
+            except (TypeError, AttributeError):
+                # then hopefully it wasn't intended to be a path
+                pass
+
+        root = root or Path(os.getcwd())
+        dummy_namespace = argparse.Namespace()
+        dummy_namespace.__dict__ = {"root": root, "command_line_args": args}
+        return dummy_namespace
 
 
 def parse_args(argv: Sequence[str]) -> tuple[_Action, str, dict[str, Any]]:
@@ -89,17 +185,22 @@ def parse_args(argv: Sequence[str]) -> tuple[_Action, str, dict[str, Any]]:
         " To learn more, try: enderchest {action} -h",
     )
 
-    action_parsers: dict[str, argparse.ArgumentParser] = {}
+    action_parsers: dict[str, argparse.ArgumentParser | PassThroughParser] = {}
     for command in actions.keys():
-        parser = argparse.ArgumentParser(
-            prog=f"enderchest {command}", description=descriptions[command]
-        )
+        if command in ("open", "close"):
+            parser: argparse.ArgumentParser | PassThroughParser = PassThroughParser(
+                prog=f"enderchest {command}", description=descriptions[command]
+            )
+        else:
+            parser = argparse.ArgumentParser(
+                prog=f"enderchest {command}", description=descriptions[command]
+            )
         parser.add_argument(
             "root",
             nargs="?",
             help=(
-                "optionally specify your root minecraft directory. If no path is given,"
-                " the current working directory will be used."
+                "optionally specify your root minecraft directory."
+                "  If no path is given, the current working directory will be used."
             ),
             type=Path,
             default=Path(os.getcwd()),
@@ -138,11 +239,18 @@ def parse_args(argv: Sequence[str]) -> tuple[_Action, str, dict[str, Any]]:
         dest="cleanup",
         help="do not remove broken links when performing place",
     )
+
+    for command in ("open", "close"):
+        action_parsers[command].add_argument(
+            "command_line_args",
+            nargs="*",
+            help="any additional arguments to pass through to the script",
+        )
+
     root_args = enderchest_parser.parse_args(argv[1:2])
     action: _Action = actions[root_args.action]
     action_kwargs = vars(action_parsers[root_args.action].parse_args(argv[2:]))
     root = action_kwargs.pop("root")
-
     return action, root, action_kwargs
 
 

--- a/enderchest/cli.py
+++ b/enderchest/cli.py
@@ -1,74 +1,150 @@
 """Command-line interface"""
 import argparse
 import os
-from functools import partial
+import sys
 from pathlib import Path
-from typing import Callable
+from typing import Any, Protocol, Sequence
 
 from . import __version__
-from .craft import craft_ender_chest
+from .craft import craft_ender_chest, craft_ender_chest_from_config
 from .place import place_enderchest
 
-_Action = Callable[[str | os.PathLike], None]
+
+class _Action(Protocol):
+    def __call__(self, root: str | os.PathLike, /) -> None:
+        ...
+
+
+def _dispatch_craft(root: str | os.PathLike, **kwargs) -> None:
+    """Call the correct craft command based on the arguments passed"""
+    if config_path := kwargs.get("config_file"):
+        craft_ender_chest_from_config(config_path)
+    else:
+        craft_ender_chest(root, *kwargs.pop("remotes", []), **kwargs)
 
 
 ACTIONS: tuple[tuple[str, str, _Action], ...] = (
     # action name, action description, action method
-    ("craft", "initialize the EnderChest folder structure", craft_ender_chest),
-    ("place", "create or update the symlinks", place_enderchest),
+    (
+        "craft",
+        "initialize the EnderChest folder structure and sync scripts",
+        _dispatch_craft,
+    ),
+    (
+        "place",
+        "create/update the links into the EnderChest folder from your"
+        " instances and servers",
+        place_enderchest,
+    ),
 )
 
 
-def parse_args(argv=None) -> tuple[_Action, Path]:
+def parse_args(argv: Sequence[str]) -> tuple[_Action, str, dict[str, Any]]:
+    """Parse the provided command-line options to determine the action to perform and
+    the arguments to pass to the action
 
+    Parameters
+    ----------
+    argv : list-like of str (sys.argv)
+        The options passed into the command line
+
+    Returns
+    -------
+    Callable
+        The action method that will be called
+    str
+        The root of the minecraft folder (parent of the EnderChest)
+        where the action will be perfomed
+    dict
+        Any additional options that will be given to the action method
+
+    """
     actions: dict[str, _Action] = {}
-    descriptions: str = ""
+    descriptions: dict[str, str] = {}
+    root_description: str = ""
     for name, description, method in ACTIONS:
         actions[name] = method
-        descriptions += f"\n\t{name}: to {description}"
+        descriptions[name] = description
+        root_description += f"\n\t{name}: to {description}"
 
-    parser = argparse.ArgumentParser(
-        prog=f"enderchest",
+    enderchest_parser = argparse.ArgumentParser(
+        prog="enderchest",
         description=(
             f"v{__version__}\n" "\nsyncing and linking for all your Minecraft instances"
         ),
         formatter_class=argparse.RawTextHelpFormatter,
     )
-    parser.add_argument(
+    enderchest_parser.add_argument(
         "action",
-        help=f"the action to perform. Options are:{descriptions}",
+        help=f"the action to perform. Options are:{root_description}",
         type=str,
         choices=actions.keys(),
     )
-    parser.add_argument(
-        "root",
-        nargs="?",
-        help=(
-            "optionally specify your root minecraft directory. If no path is given,"
-            " the current working directory will be used."
-        ),
-        type=str,
-        default=os.getcwd(),
+    enderchest_parser.add_argument(
+        "arguments",
+        nargs="*",
+        help="any additional arguments for the specific action."
+        " To learn more, try: enderchest {action} -h",
     )
-    parser.add_argument(
+
+    action_parsers: dict[str, argparse.ArgumentParser] = {}
+    for command in actions.keys():
+        parser = argparse.ArgumentParser(
+            prog=f"enderchest {command}", description=descriptions[command]
+        )
+        parser.add_argument(
+            "root",
+            nargs="?",
+            help=(
+                "optionally specify your root minecraft directory. If no path is given,"
+                " the current working directory will be used."
+            ),
+            type=Path,
+            default=Path(os.getcwd()),
+        )
+        action_parsers[command] = parser
+
+    action_parsers["craft"].add_argument(
+        "-r",
+        "--remote",
+        dest="remotes",
+        action="append",
+        help="specify a remote enderchest installation using the syntax"
+        " [user@]addreess:/path/to/enderchest",
+    )
+
+    action_parsers["craft"].add_argument(
+        "-f",
+        "--file",
+        dest="config_file",
+        action="store",
+        type=Path,
+        help="parse the enderchest installations to sync with from"
+        " the specified config file",
+    )
+
+    action_parsers["craft"].add_argument(
+        "--overwrite",
+        action="store_true",
+        help="overwrite any existing sync scripts",
+    )
+
+    action_parsers["place"].add_argument(
         "-k",
         "--keep-broken",
         action="store_true",
+        dest="cleanup",
         help="do not remove broken links when performing place",
     )
-    args = parser.parse_args(argv)
+    root_args = enderchest_parser.parse_args(argv[1:2])
+    action: _Action = actions[root_args.action]
+    action_kwargs = vars(action_parsers[root_args.action].parse_args(argv[2:]))
+    root = action_kwargs.pop("root")
 
-    action = actions[args.action]
-    if args.keep_broken:
-        if args.action != "place":
-            raise ValueError(
-                "--keep-broken flag is only valid when using the place command"
-            )
-        action = partial(action, cleanup=False)
-
-    return action, Path(args.root)
+    return action, root, action_kwargs
 
 
 def main():
-    action, root = parse_args()
-    action(root)
+    action, root, kwargs = parse_args(sys.argv)
+    print(action, root, kwargs)
+    # action(root, **kwargs)

--- a/enderchest/cli.py
+++ b/enderchest/cli.py
@@ -29,7 +29,9 @@ def parse_args(argv=None) -> tuple[_Action, Path]:
 
     parser = argparse.ArgumentParser(
         prog=f"enderchest",
-        description=f"v{__version__}\n\nsyncing and linking for all your Minecraft instances",
+        description=(
+            f"v{__version__}\n" "\nsyncing and linking for all your Minecraft instances"
+        ),
         formatter_class=argparse.RawTextHelpFormatter,
     )
     parser.add_argument(

--- a/enderchest/cli.py
+++ b/enderchest/cli.py
@@ -8,6 +8,7 @@ from typing import Any, Protocol, Sequence
 from . import __version__
 from .craft import craft_ender_chest, craft_ender_chest_from_config
 from .place import place_enderchest
+from .sync import Remote
 
 
 class _Action(Protocol):
@@ -17,10 +18,11 @@ class _Action(Protocol):
 
 def _dispatch_craft(root: str | os.PathLike, **kwargs) -> None:
     """Call the correct craft command based on the arguments passed"""
-    if config_path := kwargs.get("config_file"):
+    if config_path := kwargs.pop("config_file", None):
         craft_ender_chest_from_config(config_path)
     else:
-        craft_ender_chest(root, *kwargs.pop("remotes", []), **kwargs)
+        remotes = [Remote.from_string(spec) for spec in kwargs.pop("remotes", [])]
+        craft_ender_chest(root, *remotes, **kwargs)
 
 
 ACTIONS: tuple[tuple[str, str, _Action], ...] = (

--- a/enderchest/cli.py
+++ b/enderchest/cli.py
@@ -146,5 +146,4 @@ def parse_args(argv: Sequence[str]) -> tuple[_Action, str, dict[str, Any]]:
 
 def main():
     action, root, kwargs = parse_args(sys.argv)
-    print(action, root, kwargs)
-    # action(root, **kwargs)
+    action(root, **kwargs)

--- a/enderchest/cli.py
+++ b/enderchest/cli.py
@@ -121,7 +121,6 @@ class PassThroughParser:
         if "-h" in args or "--help" in args:
             return self._parser.parse_args(["--help"])
 
-        arguments: dict[str, Any] = {}
         root: Path | None = None
         if len(args) > 0 and not args[0].startswith("-"):
             try:

--- a/enderchest/config.py
+++ b/enderchest/config.py
@@ -63,7 +63,10 @@ class Config:
         for keyword, value in self.craft_options.items():
             if keyword == "local_alias":
                 continue
-            options[keyword] = value
+            if keyword in ("pre_open", "pre_close", "post_open", "post_close"):
+                options[keyword] = json.dumps(value)
+            else:
+                options[keyword] = value
 
         parser["options"] = options
 
@@ -77,7 +80,7 @@ class Config:
                 remote_spec["username"] = username
             for wrapper in ("pre_open", "pre_close", "post_open", "post_close"):
                 if commands := getattr(remote_sync, wrapper):
-                    remote_spec[wrapper] = str(commands)
+                    remote_spec[wrapper] = json.dumps(commands)
             parser[remote.alias] = remote_spec
         return parser
 

--- a/enderchest/config.py
+++ b/enderchest/config.py
@@ -1,0 +1,333 @@
+"""Logic for parsing configuration files"""
+import json
+import os
+import warnings
+from configparser import ConfigParser, ParsingError, SectionProxy
+from pathlib import Path
+from typing import Any, NamedTuple, Sequence
+
+from .sync import Remote
+
+
+class Config(NamedTuple):
+    local_root: Path
+    open_ops: Sequence[Remote | str]
+    close_ops: Sequence[Remote | str]
+    craft_options: dict[str, Any] = {}
+
+
+def parse_config_file(config_path: str | os.PathLike) -> Config:
+    """Parse a config file
+
+    Parameters
+    ----------
+    config_path : path
+        The path to the config file
+
+    Returns
+    -------
+    Config
+        The parsed config file contents
+    """
+    with open(config_path) as config_file:
+        return parse_config(config_file.read())
+
+
+def parse_config(contents: str) -> Config:
+    """Parse the contents of a config file
+
+    Parameters
+    ----------
+    contents : str
+        The raw config file contents
+
+    Returns
+    -------
+    Config
+        The parsed config file contents
+    """
+    parser = ConfigParser()
+    parser.read_string(contents)
+
+    local_root, options = _parse_local_section(parser["local"])
+    more_options = _parse_options_section(parser["options"])
+    for option, value in more_options.items():
+        if option in ("pre_open", "pre_close", "post_open", "post_close"):
+            options[option].extend(value)
+        elif option in options and value != options[option]:
+            raise ParsingError(f"Found conflicting values for {option}")
+        options[option] = value
+
+    open_ops: list[Remote | str] = list(options.pop("pre_open"))
+    close_ops: list[Remote | str] = list(options.pop("pre_close"))
+
+    for alias in parser.sections():
+        if alias in ("local", "options"):
+            continue
+        (pre_open, pre_close), remote, (post_open, post_close) = _parse_remote_section(
+            parser[alias]
+        )
+        open_ops.extend([*pre_open, remote, *post_open])
+        close_ops.extend([*pre_close, remote, *post_close])
+    open_ops.extend(options.pop("post_open"))
+    close_ops.extend(options.pop("post_close"))
+
+    return Config(local_root, open_ops, close_ops, options)
+
+
+def _parse_local_section(section: SectionProxy) -> tuple[Path, dict[str, Any]]:
+    """Parse the local section of the config
+
+    Parameters
+    ----------
+    section : SectionProxy
+        The local section of the config
+
+    Returns
+    -------
+    Path
+        The local root folder
+    dict
+        Any keyword options to pass to the craft command
+
+    Raises
+    ------
+    ParsingError
+        If a required parameter isn't present or if a given option cannot be parsed
+    """
+    try:
+        root = Path(section["root"])
+    except KeyError:
+        raise ParsingError("Config must explicitly specify a local root directory")
+    except (TypeError, ValueError):
+        raise ParsingError(
+            f'Invalid value for root parameter in local config: {section["root"]} '
+        )
+
+    alias_option_names = {"name", "alias"}
+    if len(alias_option_names.intersection(section.keys())) > 1:
+        raise ParsingError(
+            f"Found conflicting values for local installation's name/alias"
+        )
+
+    for option_name in alias_option_names:
+        try:
+            local_alias = _parse_string(section.get(option_name))
+        except (TypeError, ValueError):
+            raise ParsingError(
+                f"Invalid value for {option_name} option in local config:"
+                f" {section[option_name]}"
+            )
+        if local_alias:
+            break
+    else:
+        local_alias = None
+
+    # options can also be provided in local section
+    return root, {"local_alias": local_alias, **_parse_options_section(section)}
+
+
+def _parse_options_section(section: SectionProxy) -> dict[str, Any]:
+    """Parse the local section of the config
+
+    Parameters
+    ----------
+    section : SectionProxy
+        The options section of the config
+
+    Returns
+    -------
+    dict
+        Keyword options to pass to the craft command
+
+    Raises
+    ------
+    ParsingError
+        If a required parameter isn't present or if a given option cannot be parsed
+    """
+    options: dict[str, Any] = {}
+
+    if "generate_runnable_scripts" in section:
+        omit_scare_warnings: bool | str | None = None
+        # first try parsing as a boolean
+        try:
+            omit_scare_warnings = section.getboolean("generate_runnable_scripts")
+        except ValueError:
+            pass
+        if omit_scare_warnings is False:
+            pass
+        elif (
+            _parse_string(section["generate_runnable_scripts"])
+            == "I acknowledge that this is dangerous"
+        ):
+            # you said the magic word!
+            omit_scare_warnings = True
+        else:
+            # you didn't say the magic word
+            warnings.warn(
+                "Setting provided to generate_runnable_scripts"
+                " option does not contain explicit risk acknowledgement."
+                "\nTreating as False."
+            )
+            omit_scare_warnings = False
+        options["omit_scare_warnings"] = omit_scare_warnings
+
+    if "overwrite_scripts" in section:
+        try:
+            options["overwrite"] = section.getboolean("overwrite_scripts") or False
+        except ValueError:
+            raise ParsingError(
+                "Expected boolean value for overwrite_scripts option."
+                f' Got {section.get("overwrite_scripts")} instead.'
+            )
+    options.update(_parse_pre_and_post_commands(section))
+    return options
+
+
+def _parse_remote_section(
+    section: SectionProxy,
+) -> tuple[tuple[list[str], list[str]], Remote, tuple[list[str], list[str]]]:
+    """Parse a remote section
+
+    Parameters
+    ----------
+    section : SectionProxy
+        A section of the config specifying a remote source
+
+    Returns
+    -------
+    tuple of two lists of str
+        The list of commands to execute immediately before running the "open" and
+        "close" rsync scripts, respectively, for this particular remote
+    Remote
+        The specification of this remote
+    tuple of two lists of str
+        The list of commands to execute immediately after running the "open" and
+        "close" rsync scripts, respectively, for this particular remote
+
+    Raises
+    ------
+    ParsingError
+        If a required parameter isn't present or if a given option cannot be parsed
+    """
+    alias = _parse_string(section.name)
+
+    host_option_names = {"host", "hostname", "url", "address"}
+    if len(host_option_names.intersection(section.keys())) > 1:
+        raise ParsingError(
+            f"Found conflicting values for hostname/address in config {alias}"
+        )
+
+    for option_name in host_option_names:
+        try:
+            host = _parse_string(section.get(option_name))
+        except (TypeError, ValueError):
+            raise ParsingError(
+                f"Invalid value for {option_name} parameter in config {alias}:"
+                f" {section[option_name]}"
+            )
+        if host:
+            break
+    else:
+        host = alias
+
+    try:
+        root = Path(section["root"])
+    except KeyError:
+        raise ParsingError(f"{alias} remote config must specify a root directory")
+    except (TypeError, ValueError):
+        raise ParsingError(
+            f'Invalid value for root parameter in config {alias}: {section["root"]}'
+        )
+
+    if "user" in section and "username" in section:
+        raise ParsingError(
+            f"Found conflicting values for user/username in config {alias}"
+        )
+    try:
+        username = _parse_string(section.get("username", section.get("user")))
+    except (TypeError, ValueError):
+        raise ParsingError(
+            f'Invalid value for username parameter in config {alias}: {section["host"]}'
+        )
+
+    wrapper_commands = _parse_pre_and_post_commands(section)
+    return (
+        (wrapper_commands["pre_open"], wrapper_commands["pre_close"]),
+        Remote(host, root, username, alias),
+        (wrapper_commands["post_open"], wrapper_commands["post_close"]),
+    )
+
+
+def _parse_pre_and_post_commands(
+    section: SectionProxy,
+) -> dict[str, list[str]]:
+    """Parse the provided section to rerun the pre- and post-, -open and -close commands
+
+    Parameters
+    ----------
+    section : SectionProxy
+        A section of the config
+
+    Returns
+    -------
+    dict of str to lists of str
+        A mapping that provides the pre- and post-, -open and -close commands
+    """
+    return {
+        f"{timing}_{script}": _parse_pre_or_post_command_entry(
+            section.get(f"{timing}_{script}")
+        )
+        for timing in ("pre", "post")
+        for script in ("open", "close")
+    }
+
+
+def _parse_pre_or_post_command_entry(entry: str | None) -> list[str]:
+    """Parse a config entry for:
+        - pre_open
+        - pre_close
+        - post_open
+        - post_close
+
+    Parameters
+    ----------
+    entry : str or None
+        The raw entry
+
+    Returns
+    -------
+    list of str
+        The parsed commands
+    """
+    if entry is None:
+        return []
+    try:
+        parsed = json.loads(entry)
+    except json.JSONDecodeError:
+        parsed = entry
+    if isinstance(parsed, str):
+        parsed = [_parse_string(parsed)]
+    return parsed
+
+
+def _parse_string(entry: str | None) -> str | None:
+    """Strip quotes from strings
+
+    Parameters
+    ----------
+    entry : str or None
+        The raw entry
+
+    Returns
+    -------
+    str or None
+        The de-quoted string, or None if the raw entry was None
+    """
+    if entry is None:
+        return None
+    for quote_char in ('"""', "'''", "'", '"'):
+        if entry.startswith(quote_char) and entry.endswith(quote_char):
+            return entry[len(quote_char) : -len(quote_char)]
+    # if not quoted
+    return entry

--- a/enderchest/config.py
+++ b/enderchest/config.py
@@ -3,7 +3,7 @@ import json
 import os
 import warnings
 from configparser import ConfigParser, ParsingError, SectionProxy
-from pathlib import PurePosixPath
+from pathlib import Path
 from typing import Any, Sequence
 
 from .sync import Remote, RemoteSync
@@ -41,7 +41,7 @@ class Config:
 
     def __init__(
         self,
-        local_root: os.PathLike,
+        local_root: str | os.PathLike,
         remotes: Sequence[RemoteSync],
         craft_options: dict[str, Any] | None = None,
     ):
@@ -159,7 +159,7 @@ def parse_config(contents: str) -> Config:
     return Config(local_root, remotes, options)
 
 
-def _parse_local_section(section: SectionProxy) -> tuple[os.PathLike, dict[str, Any]]:
+def _parse_local_section(section: SectionProxy) -> tuple[str, dict[str, Any]]:
     """Parse the local section of the config
 
     Parameters
@@ -169,7 +169,7 @@ def _parse_local_section(section: SectionProxy) -> tuple[os.PathLike, dict[str, 
 
     Returns
     -------
-    Path
+    str
         The local root folder
     dict
         Any keyword options to pass to the craft command
@@ -180,7 +180,7 @@ def _parse_local_section(section: SectionProxy) -> tuple[os.PathLike, dict[str, 
         If a required parameter isn't present or if a given option cannot be parsed
     """
     try:
-        root = PurePosixPath(section["root"])
+        root = Path(section["root"]).as_posix()
     except KeyError:
         raise ParsingError("Config must explicitly specify a local root directory")
     except (TypeError, ValueError):
@@ -310,7 +310,7 @@ def _parse_remote_section(
         host = alias
 
     try:
-        root = PurePosixPath(section["root"])
+        root = Path(section["root"]).as_posix()
     except KeyError:
         raise ParsingError(f"{alias} remote config must specify a root directory")
     except (TypeError, ValueError):

--- a/enderchest/config.py
+++ b/enderchest/config.py
@@ -3,7 +3,7 @@ import json
 import os
 import warnings
 from configparser import ConfigParser, ParsingError, SectionProxy
-from pathlib import Path
+from pathlib import PurePosixPath
 from typing import Any, Sequence
 
 from .sync import Remote, RemoteSync
@@ -41,7 +41,7 @@ class Config:
 
     def __init__(
         self,
-        local_root: Path,
+        local_root: os.PathLike,
         remotes: Sequence[RemoteSync],
         craft_options: dict[str, Any] | None = None,
     ):
@@ -159,7 +159,7 @@ def parse_config(contents: str) -> Config:
     return Config(local_root, remotes, options)
 
 
-def _parse_local_section(section: SectionProxy) -> tuple[Path, dict[str, Any]]:
+def _parse_local_section(section: SectionProxy) -> tuple[os.PathLike, dict[str, Any]]:
     """Parse the local section of the config
 
     Parameters
@@ -180,7 +180,7 @@ def _parse_local_section(section: SectionProxy) -> tuple[Path, dict[str, Any]]:
         If a required parameter isn't present or if a given option cannot be parsed
     """
     try:
-        root = Path(section["root"])
+        root = PurePosixPath(section["root"])
     except KeyError:
         raise ParsingError("Config must explicitly specify a local root directory")
     except (TypeError, ValueError):
@@ -310,7 +310,7 @@ def _parse_remote_section(
         host = alias
 
     try:
-        root = Path(section["root"])
+        root = PurePosixPath(section["root"])
     except KeyError:
         raise ParsingError(f"{alias} remote config must specify a root directory")
     except (TypeError, ValueError):

--- a/enderchest/config.py
+++ b/enderchest/config.py
@@ -191,7 +191,7 @@ def _parse_local_section(section: SectionProxy) -> tuple[Path, dict[str, Any]]:
     alias_option_names = {"name", "alias"}
     if len(alias_option_names.intersection(section.keys())) > 1:
         raise ParsingError(
-            f"Found conflicting values for local installation's name/alias"
+            "Found conflicting values for local installation's name/alias"
         )
 
     for option_name in alias_option_names:

--- a/enderchest/config.py
+++ b/enderchest/config.py
@@ -15,6 +15,8 @@ class Config(NamedTuple):
     close_ops: Sequence[Remote | str]
     craft_options: dict[str, Any] = {}
 
+    # TODO: add serializer
+
 
 def parse_config_file(config_path: str | os.PathLike) -> Config:
     """Parse a config file

--- a/enderchest/craft.py
+++ b/enderchest/craft.py
@@ -6,13 +6,13 @@ from . import contexts
 
 # sometimes you just need a CSV
 _FOLDER_CONTEXT_COMBOS = """
-folder/cpmtext, universal, client_only, local_only, server_only
-config,         yes,       yes,         yes,        yes
-mods,           yes,       yes,         yes,        yes
-resourcepacks,  yes,       yes,         yes,        no
-saves,          no,        yes,         yes,        yes
-shaderpacks,    no,        yes,         yes,        no
-"""
+folder/context, universal, client_only, server_only, local_only
+config,         yes,       yes,         yes,         yes
+mods,           yes,       yes,         yes,         yes
+resourcepacks,  yes,       yes,         no,          yes
+saves,          no,        yes,         yes,         yes
+shaderpacks,    no,        yes,         no,          yes
+"""  # mote: the omission of other_locals is intentional -- it shouldn't get any minecraft folders
 
 
 def _parse_folder_context_combos() -> dict[str, set[str]]:
@@ -45,5 +45,6 @@ def craft_ender_chest(root: str | os.PathLike) -> None:
     """
     folders_for_contexts = _parse_folder_context_combos()
     for context_type, context_root in contexts(root)._asdict().items():
+        context_root.mkdir(parents=True, exist_ok=True)
         for folder in folders_for_contexts[context_type]:
             (context_root / folder).mkdir(parents=True, exist_ok=True)

--- a/enderchest/craft.py
+++ b/enderchest/craft.py
@@ -4,6 +4,22 @@ from collections import defaultdict
 
 from . import contexts
 
+
+def craft_ender_chest(root: str | os.PathLike) -> None:
+    """Create the EnderChest folder structure in the specified root directory
+
+    Parameters
+    ----------
+    root : path
+        The root directory to put the EnderChest folder structure into
+    """
+    folders_for_contexts = _parse_folder_context_combos()
+    for context_type, context_root in contexts(root)._asdict().items():
+        context_root.mkdir(parents=True, exist_ok=True)
+        for folder in folders_for_contexts[context_type]:
+            (context_root / folder).mkdir(parents=True, exist_ok=True)
+
+
 # sometimes you just need a CSV
 _FOLDER_CONTEXT_COMBOS = """
 folder/context, universal, client_only, server_only, local_only
@@ -12,7 +28,7 @@ mods,           yes,       yes,         yes,         yes
 resourcepacks,  yes,       yes,         no,          yes
 saves,          no,        yes,         yes,         yes
 shaderpacks,    no,        yes,         no,          yes
-"""  # mote: the omission of other_locals is intentional -- it shouldn't get any minecraft folders
+"""  # mote: omission of other_locals is intentional as remote names are top-level there
 
 
 def _parse_folder_context_combos() -> dict[str, set[str]]:
@@ -33,18 +49,3 @@ def _parse_folder_context_combos() -> dict[str, set[str]]:
             if value == "yes":
                 folders_for_contexts[contexts[i]].add(folder)
     return folders_for_contexts
-
-
-def craft_ender_chest(root: str | os.PathLike) -> None:
-    """Create the EnderChest folder structure in the specified root directory
-
-    Parameters
-    ----------
-    root : path
-        The root directory to put the EnderChest folder structure into
-    """
-    folders_for_contexts = _parse_folder_context_combos()
-    for context_type, context_root in contexts(root)._asdict().items():
-        context_root.mkdir(parents=True, exist_ok=True)
-        for folder in folders_for_contexts[context_type]:
-            (context_root / folder).mkdir(parents=True, exist_ok=True)

--- a/enderchest/place.py
+++ b/enderchest/place.py
@@ -23,14 +23,16 @@ def place_enderchest(root: str | os.PathLike, cleanup: bool = True) -> None:
         make_server_links = context_type in ("universal", "server_only")
         make_instance_links = context_type in ("universal", "client_only", "local_only")
 
-        links = sorted(context_root.rglob("*@*"))
-        for link in links:
-            path, *tags = str(link.relative_to(context_root)).split("@")
+        assets = sorted(context_root.rglob("*@*"))
+        for asset in assets:
+            if not asset.exists():
+                continue
+            path, *tags = str(asset.relative_to(context_root)).split("@")
             for tag in tags:
                 if make_instance_links:
-                    link_instance(path, instances / tag, link)
+                    link_instance(path, instances / tag, asset)
                 # if make_server_links:
-                #     link_server(path, instances / tag, link)
+                #     link_server(path, instances / tag, asset)
     if cleanup:
         for file in (*instances.rglob("*"), *servers.rglob("*")):
             if not file.exists():

--- a/enderchest/place.py
+++ b/enderchest/place.py
@@ -62,7 +62,11 @@ def link_instance(
 
     Notes
     -----
-    This method will create any folders that do not existc
+    - This method will create any folders that do not exist within an instance, but only
+      if the instance folder exists and has contains a ".minecraft" folder *or* if
+      check_exists is set to False
+    - This method will overwrite existing symlinks but will not overwrite any actual
+      files.
     """
     if not (instance_folder / ".minecraft").exists() and check_exists:
         return

--- a/enderchest/place.py
+++ b/enderchest/place.py
@@ -11,9 +11,10 @@ def place_enderchest(root: str | os.PathLike, cleanup: bool = True) -> None:
     Parameters
     ----------
     root : path
-        The root directory that contains both the EnderChest directory, instances and servers
+        The root directory that contains the EnderChest directory, instances and servers
     cleanup : bool, optional
-        By default, this method will remove any broken links in your instances and servers folders.
+        By default, this method will remove any broken links in your instances and
+        servers folders.
         To disable this behavior, pass in cleanup=False
     """
     instances = Path(root) / "instances"
@@ -39,8 +40,8 @@ def place_enderchest(root: str | os.PathLike, cleanup: bool = True) -> None:
 def link_instance(
     resource_path: str, instance_folder: Path, destination: Path, check_exists=True
 ) -> None:
-    """Create a symlink for the specified resource from an instance's space pointing to the
-    tagged file / folder living in the EnderChest folder.
+    """Create a symlink for the specified resource from an instance's space pointing to
+    the tagged file / folder living in the EnderChest folder.
 
     Parameters
     ----------
@@ -49,10 +50,11 @@ def link_instance(
     instance_folder : Path
         the instance's folder (parent of ".minecraft")
     destination : Path
-        the location to link, where the file or older actually lives (inside the EnderChest folder)
+        the location to link, where the file or older actually lives (inside the
+        EnderChest folder)
     check_exists : bool, optional
-        By default, this method will only create links if a ".minecraft" folder exists in the
-        instance_folder. To create links regardless, pass check_exists=False
+        By default, this method will only create links if a ".minecraft" folder exists
+        in the instance_folder. To create links regardless, pass check_exists=False
 
     Returns
     -------
@@ -85,7 +87,8 @@ def link_server(resource_path: str, server_folder: Path, destination: Path) -> N
     server_folder : Path
         the server's  folder
     destination : Path
-        the location to link, where the file or older actually lives (inside the EnderChest folder)
+        the location to link, where the file or older actually lives (inside the
+        EnderChest folder)
 
     Returns
     -------

--- a/enderchest/place.py
+++ b/enderchest/place.py
@@ -20,7 +20,7 @@ def place_enderchest(root: str | os.PathLike, cleanup: bool = True) -> None:
     instances = Path(root) / "instances"
     servers = Path(root) / "servers"
     for context_type, context_root in contexts(root)._asdict().items():
-        make_server_links = context_type in ("universal", "server_only")
+        # make_server_links = context_type in ("universal", "server_only")
         make_instance_links = context_type in ("universal", "client_only", "local_only")
 
         assets = sorted(context_root.rglob("*@*"))
@@ -83,8 +83,8 @@ def link_instance(
 
 
 def link_server(resource_path: str, server_folder: Path, destination: Path) -> None:
-    """Create a symlink for the specified resource from an server's space pointing to the
-    tagged file / folder living in the EnderChest folder.
+    """Create a symlink for the specified resource from an server's space pointing to
+    the tagged file / folder living in the EnderChest folder.
 
     Parameters
     ----------

--- a/enderchest/sync.py
+++ b/enderchest/sync.py
@@ -149,8 +149,7 @@ def link_to_other_chests(
                 warning_message += " Overwriting."
                 warnings.warn(warning_message)
 
-        with script_path.open("w") as script_file:
-            script_file.write(script)
+        script_path.write_text(script)
 
 
 HEADER = """#!/usr/bin/env bash

--- a/enderchest/sync.py
+++ b/enderchest/sync.py
@@ -1,6 +1,7 @@
 """Utilities for synchronizing chests across different computers"""
 import os
 import socket
+import stat
 import warnings
 from pathlib import Path
 from typing import NamedTuple
@@ -150,6 +151,7 @@ def link_to_other_chests(
                 warnings.warn(warning_message)
 
         script_path.write_text(script)
+        script_path.chmod(script_path.stat().st_mode | stat.S_IEXEC)
 
 
 HEADER = """#!/usr/bin/env bash

--- a/enderchest/sync.py
+++ b/enderchest/sync.py
@@ -95,6 +95,10 @@ def link_to_other_chests(
     local_alias: str | None = None,
     overwrite: bool = False,
     omit_scare_message: bool = False,
+    pre_open: Sequence[str] | None = None,
+    pre_close: Sequence[str] | None = None,
+    post_open: Sequence[str] | None = None,
+    post_close: Sequence[str] | None = None,
 ) -> None:
     """Generate bash scripts for syncing to EnderChest installations on other computers.
     These will be saved in your EnderChest/local-only folder under `open.sh`
@@ -121,6 +125,14 @@ def link_to_other_chests(
         trust* this method and the use of it, pass in the keyword argument
         omit_scare_message=True to omit this safeguard and just make them runnable from
         the get-go.
+    pre_open: list of str, optional
+        Any commands to run before pulling in EnderChest changes from the remotes
+    pre_close: list of str, optional
+        Any commands to run before pushing EnderChest changes to the remotes
+    post_open: list of str, optional
+        Any commands to run after pulling in EnderChest changes from the remotes
+    post_close: list of str, optional
+        Any commands to run after pushing EnderChest changes to the remotes
 
     Returns
     -------
@@ -153,6 +165,12 @@ def link_to_other_chests(
         close_script += SCARE_MESSAGE
 
     open_script += "\n"
+
+    if pre_open:
+        open_script += "".join([f"{command}\n" for command in pre_open])
+    if pre_close:
+        close_script += "".join([f"{command}\n" for command in pre_close])
+
     for remote in remotes:
         yeet, yoink = _build_rsync_scripts(
             local_root, local_alias or socket.gethostname(), remote
@@ -166,6 +184,11 @@ def link_to_other_chests(
     exit 1
 }
 """
+
+    if post_open:
+        open_script += "".join([f"{command}\n" for command in post_open])
+    if post_close:
+        close_script += "".join([f"{command}\n" for command in post_close])
 
     for name, script in (("open", open_script), ("close", close_script)):
         script_path = contexts(local_root).local_only / f"{name}.sh"

--- a/enderchest/sync.py
+++ b/enderchest/sync.py
@@ -7,58 +7,36 @@ from typing import NamedTuple
 
 from . import contexts
 
-HEADER = """#!/usr/bin/env bash
-set -e
-"""
-
-SCARE_MESSAGE = """
-########################## DELETE AFTER READING ########################################
-echo "These scripts were auto-generated and should be checked before first running!"
-echo "Please open" $(realpath "$0")
-echo "and read through the entire script to make sure it's doing what you want,"
-echo "then delete the section marked "DELETE AFTER READING" near the top of the file."
-echo
-echo "It's also *strongly recommended* to run the commands first with
-echo "the flags: --dry-run --verbose to make absolutely sure the script is doing 
-echo "what you want before you potentially overwrite an entire file system."
-exit 1
-#########################################################################################
-"""
-
-SHARED_SYNC = """# sync changes from {source_desc} to {destination_desc}
-rsync {options} {source}/EnderChest/ {destination}/EnderChest/ {exclusions} "$@"
-"""
-
-LOCAL_BACKUP = """# backup local settings to {remote_desc}
-rsync {options} {local_root}/EnderChest/local-only {remote_root}/EnderChest/other-locals/{local_desc} "$@"
-"""
-
 
 # TODO: is there something from the stdlib (urllib?) that I should be using instead?
 class Remote(NamedTuple):
-    """Specification of a remote EnderChest installation to sync with using rsync over ssh (other protocols are not
-    explicitly supported).
+    """Specification of a remote EnderChest installation to sync with using rsync over
+    ssh (other protocols are not explicitly supported).
 
     Attributes
     ----------
     host : str
-        The address (_e.g._ 127.0.0.1) or cname/URL (_e.g._ steamdeck.local) of the host you're syncing with.
+        The address (_e.g._ 127.0.0.1) or cname/URL (_e.g._ steamdeck.local) of the
+        host you're syncing with.
     root : path-like
-        The root directory on the remote machine that contains all your minecraft stuff. Explicitly expects that
-        the folder contains: your EnderChest folder; your Multi-MC-style instances folder; your servers.
+        The root directory on the remote machine that contains all your minecraft stuff.
+        Explicitly expects that the folder contains: your EnderChest folder;
+        your Multi-MC-style instances folder; your servers.
     username : str, optional
-        The username for logging onto the remote machine. If None is specified on instantiation, it's assumed that
-        you don't need a username to log into the server from this local.
+        The username for logging onto the remote machine. If None is specified on
+        instantiation, it's assumed that you don't need a username to log into the
+        server from this local.
     alias : str
-        A shorthand way to refer to the remote installation. If None is specified on instantiation,
-        this will be the same as the host attribute.
+        A shorthand way to refer to the remote installation. If None is specified on
+        instantiation, this will be the same as the host attribute.
     remote_folder : str
-        The full specification of the remote root, _e.g._ deck@steamdeck.local:~/minecraft
+        The full specification of the remote root, _e.g._
+        deck@steamdeck.local:~/minecraft
 
     Notes
     -----
-    This class is not designed to be safe against injection attacks and has none of the protections you'd get out
-    of using, say, the urllib.parse module.
+    This class is not designed to be safe against injection attacks and has none of the
+    protections you'd get out of using, say, the urllib.parse module.
     """
 
     host: str
@@ -79,19 +57,151 @@ class Remote(NamedTuple):
         return f"{url}:{self.root}"
 
 
-def _build_rsync_scripts(
-    local_root: str | os.PathLike, local_alias: str, remote: Remote
-) -> tuple[str, str]:
-    """Build two rsync scripts: one for pushing local changes to a remote instance and another for pulling remote
-    changes to the local
+def link_to_other_chests(
+    local_root: str | os.PathLike,
+    *remotes: Remote,
+    local_alias: str | None = None,
+    overwrite: bool = False,
+    omit_scare_message: bool = False,
+) -> None:
+    """Generate bash scripts for syncing to EnderChest installations on other computers.
+    These will be saved in your EnderChest/local-only folder under `open.sh`
+    (for pulling from remotes) and `close.sh` (for pushing to other remotes)
 
     Parameters
     ----------
     local_root : path
-        The local root directory that contains both the EnderChest directory, instances and servers
+        The local root directory that contains both the EnderChest directory, instances
+        and servers
+    *remotes : Remotes
+        The remote installations to sync with
+    local_alias : str, optional
+        A shorthand way to refer to the local installation. This is what determines the
+        name of the local settings backup folder inside remote "other-locals" folders.
+        If None is specified, this computer's hostname will be used.
+    overwrite : bool, optional
+        By default, if an open/close script exists, this method will leave it alone.
+        To instead overwrite any existing scripts, explicitly pass in the keyword
+        argument overwrite=True
+    omit_scare_message : bool, optional
+        By default, the scripts this method generates are not runnable and tell the user
+        to first open them in a text editor and look them over. If you *really really
+        trust* this method and the use of it, pass in the keyword argument
+        omit_scare_message=True to omit this safeguard and just make them runnable from
+        the get-go.
+
+    Returns
+    -------
+    None
+
+    Warnings
+    --------
+    If one of the scripts already exists, this method will emit a warning that
+    generation of a new script is being kipped (if overwrite=True is not specified) or
+    that the old script is being overwritten (if this method is called with
+    overwrite=True).
+
+    Notes
+    -----
+    - This method is designed for flexibility and transparency over robustness and ease
+      of use. That means that **you need to open the scripts this function generates**
+      and look them over before ou can actually run them. This also gives you a chance
+      add your own tweaks and customizations before embedding the syncing into your
+      automations.
+    - The remotes are assumed to be specified in **priority order**
+      (top priority first), meaning the first remote:
+      - will be the first to receive local changes
+      - will be the first to try pulling remote changes from
+    """
+    open_script = HEADER
+    close_script = HEADER
+
+    if not omit_scare_message:
+        open_script += SCARE_MESSAGE
+        close_script += SCARE_MESSAGE
+
+    open_script += "\n"
+    for remote in remotes:
+        yeet, yoink = _build_rsync_scripts(
+            local_root, local_alias or socket.gethostname(), remote
+        )
+        close_script += "\n" + yeet
+        open_script += "{\n    " + "\n    ".join(yoink.split("\n")[:-1]) + "\n} || "
+
+    open_script += """{
+    echo "Could not pull changes from any remote EnderChests."
+    echo "Are you outside your local network?"
+    exit 1
+}
+"""
+
+    for name, script in (("open", open_script), ("close", close_script)):
+        script_path = contexts(local_root).local_only / f"{name}.sh"
+
+        if script_path.exists():
+            warning_message = f"{name.title()} script already exists."
+
+            if not overwrite:
+                warning_message += " Skipping."
+                warnings.warn(warning_message)
+                continue
+            else:
+                warning_message += " Overwriting."
+                warnings.warn(warning_message)
+
+        with script_path.open("w") as script_file:
+            script_file.write(script)
+
+
+HEADER = """#!/usr/bin/env bash
+set -e
+"""
+
+SCARE_MESSAGE = """
+########################## DELETE AFTER READING ########################################
+echo "These scripts were auto-generated and should be checked before first running!"
+echo "Please open" $(realpath "$0")
+echo "and read through the entire script to make sure it's doing what you want,"
+echo "then delete the section marked "DELETE AFTER READING" near the top of the file."
+echo
+echo "It's also *strongly recommended* to run the commands first with
+echo "the flags: --dry-run --verbose to make absolutely sure the script is doing 
+echo "what you want before you potentially overwrite an entire file system."
+exit 1
+########################################################################################
+"""
+
+SHARED_SYNC = """# sync changes from {source_desc} to {destination_desc}
+rsync {options} \\
+    {source}/EnderChest/ \\
+    {destination}/EnderChest/ \\
+    {exclusions} \\
+    "$@"
+"""
+
+LOCAL_BACKUP = """# backup local settings to {remote_desc}
+rsync {options} \\
+    {local_root}/EnderChest/local-only \\
+    {remote_root}/EnderChest/other-locals/{local_desc} \\
+    "$@"
+"""
+
+
+def _build_rsync_scripts(
+    local_root: str | os.PathLike, local_alias: str, remote: Remote
+) -> tuple[str, str]:
+    """Build two rsync scripts: one for pushing local changes to a remote instance and
+    another for pulling remote changes to the local
+
+    Parameters
+    ----------
+    local_root : path
+        The local root directory that contains both the EnderChest directory, instances
+        and servers
     local_alias : str
-        A shorthand way to refer to the local installation. This is what determines the name of the local settings
-        backup folder inside the remote machine's "other-locals" folder.
+        A shorthand way to refer to the local installation. This is what determines the
+        name of the local settings backup folder inside the remote installation's
+        "other-locals" folder.
     remote : Remote
         The specification of the installation you're wanting to sync with
 
@@ -104,17 +214,21 @@ def _build_rsync_scripts(
 
     Notes
     -----
-    - This method omits the header (shebang and set -e) from the generated scripts, as the intent is to allow for
-      combining multiple calls into two large scripts.
-    - This method is not designed to be safe against injection attacks--the goal is to generate **scripts** that the
-      user can then tweak and modify before calling manually.
-    - The local backup part of the script will assume that this computer's hostname is the best way to reference this
-      EnderChest installation in the remote's "other-locals" folder. That's not going to be ideal if you're managing,
-      say, multiple installations on the same computer (like, across separate user accounts?).
+    - This method omits the header (shebang and set -e) from the generated scripts, as
+      the intent is to allow for combining multiple calls into two large scripts.
+    - This method is not designed to be safe against injection attacks--the goal is to
+      generate **scripts** that the user can then tweak and modify before calling
+      manually.
+    - The local backup part of the script will assume that this computer's hostname is
+      the best way to reference this EnderChest installation in the remote's
+      "other-locals" folder. That's not going to be ideal if you're managing,
+      say, multiple installations on the same computer (like, across separate user
+      accounts?).
     """
     options = "-az --delete"
     # TODO: make z toggleable (to support local copies)
-    # TODO: set timeout and controls around the conditions under you expect the remote to be accessible, _i,e,_
+    # TODO: set timeout and controls around the conditions under you expect the remote
+    #  to be accessible, _i,e,_
     #       - internet-accessible (for a server you can access outside the LAN
     #       - always-on (for desktops that don't get turned off when not in use)
     exclusion_folders = (".git", "local-only", "other-locals")
@@ -145,91 +259,3 @@ def _build_rsync_scripts(
     )
 
     return yeet, yoink
-
-
-def link_to_other_chests(
-    local_root: str | os.PathLike,
-    *remotes: Remote,
-    local_alias: str | None = None,
-    overwrite: bool = False,
-    omit_scare_message: bool = False,
-) -> None:
-    """Generate bash scripts for syncing to EnderChest installations on other computers. These will be saved in
-    your EnderChest/local-only folder under `open.sh` (for pulling from remotes) and `close.sh` (for pushing to other
-    remotes)
-
-    Parameters
-    ----------
-    local_root : path
-        The local root directory that contains both the EnderChest directory, instances and servers
-    *remotes : Remotes
-        The remote installations to sync with
-    local_alias : str, optional
-        A shorthand way to refer to the local installation. This is what determines the name of the local settings
-        backup folder inside remote "other-locals" folders. If None is specified, this computer's hostname will be
-        used.
-    overwrite : bool, optional
-        By default, if an open/close script exists, this method will leave it alone. To instead overwrite any existing
-        scripts, explicitly pass in the keyword argument overwrite=True
-    omit_scare_message : bool, optional
-        By default, the scripts this method generates are not runnable and tell the user to first open them in a text
-        editor and look them over. If you *really really trust* this method and your use of it, pass in the
-        keyword argument omit_scare_message=True to omit this safeguard and just make them runnable from the get-go.
-
-    Returns
-    -------
-    None
-
-    Warnings
-    --------
-    If one of the scripts already exists, this method will emit a warning that generation of a new script is being
-    skipped (if overwrite=True is not specified) or that the old script is being overwritten (if this method is called
-    with overwrite=True).
-
-    Notes
-    -----
-    - This method is designed for flexibility and transparency over robustness and ease of use. That means that
-      **you need to open the scripts this function generates** and look them over before you can actually run them. This
-      also gives you a chance add your own tweaks and customizations before first use.
-    - The remotes are assumed to be specified in **priority order** (top priority first), meaning the first remote:
-      - will be the first to receive local changes
-      - will be the first to try pulling remote changes from
-    """
-
-    open_script = HEADER
-    close_script = HEADER
-
-    if not omit_scare_message:
-        open_script += SCARE_MESSAGE
-        close_script += SCARE_MESSAGE
-
-    open_script += "\n"
-    for remote in remotes:
-        yeet, yoink = _build_rsync_scripts(
-            local_root, local_alias or socket.gethostname(), remote
-        )
-        close_script += "\n" + yeet
-        open_script += "{\n    " + "\n    ".join(yoink.split("\n")[:-1]) + "\n} || "
-
-    open_script += """{
-    echo "Could not pull changes from any remote EnderChests. Are you outside your local network?"
-    exit 1
-}
-"""
-
-    for name, script in (("open", open_script), ("close", close_script)):
-        script_path = contexts(local_root).local_only / f"{name}.sh"
-
-        if script_path.exists():
-            warning_message = f"{name.title()} script already exists."
-
-            if not overwrite:
-                warning_message += " Skipping."
-                warnings.warn(warning_message)
-                continue
-            else:
-                warning_message += " Overwriting."
-                warnings.warn(warning_message)
-
-        with script_path.open("w") as script_file:
-            script_file.write(script)

--- a/enderchest/sync.py
+++ b/enderchest/sync.py
@@ -5,7 +5,7 @@ import socket
 import stat
 import warnings
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import PosixPath
 from typing import NamedTuple, Sequence
 
 from . import contexts
@@ -48,7 +48,7 @@ class Remote(NamedTuple):
 
     @property
     def alias(self) -> str:
-        return self.alias_ or self.host or Path(self.root).name
+        return self.alias_ or self.host or PosixPath(self.root).name
 
     @property
     def _encoded_root(self) -> str:
@@ -334,7 +334,7 @@ def _build_rsync_scripts(
     yoink = "".join([f"{command}\n" for command in remote.pre_open])
     yeet = "".join([f"{command}\n" for command in remote.pre_close])
 
-    local_root_path = shlex.quote(str(Path(local_root).expanduser().resolve()))
+    local_root_path = shlex.quote(str(PosixPath(local_root).expanduser().resolve()))
 
     yeet += SHARED_SYNC.format(
         source_desc="this EnderChest",

--- a/enderchest/sync.py
+++ b/enderchest/sync.py
@@ -1,0 +1,150 @@
+"""Utilities for synchronizing chests across different computers"""
+import os
+import socket
+from pathlib import Path
+import warnings
+
+from . import contexts
+
+
+HEADER = """#!/usr/bin/env bash
+set -e
+
+########################## DELETE AFTER READING ########################################
+echo "These scripts were auto-generated and should be checked before first running!"
+echo "Please open" $(realpath "$0")
+echo "and read through the entire script to make sure it's doing what you want,"
+echo "then delete the section marked "DELETE AFTER READING" near the top of the file."
+echo
+echo "It's also *strongly recommended* to run the commands first with
+echo "the flags: --dry-run --verbose to make absolutely sure the script is doing 
+echo "what you want before you potentially overwrite an entire file system."
+exit 1
+#########################################################################################
+
+"""
+
+SHARED_SYNC = """# sync changes from {source_desc} to {destination_desc}
+rsync {options} {source}/EnderChest/ {destination}/EnderChest/ {exclusions} "$@"
+"""
+
+LOCAL_BACKUP = """# backup local settings to {remote}
+rsync {options} {local_root}/EnderChest/local-only/ {remote}:{remote_root}/EnderChest/other-locals/{hostname}/. "$@"
+"""
+
+
+def _build_rsync_scripts(
+    local_root: str | os.PathLike, remote: str, remote_root: str | os.PathLike
+) -> tuple[str, str]:
+    """Build two rsync scripts: one for pushing local changes to a remote instance and another for pulling remote
+    changes to the local
+
+    Parameters
+    ----------
+    local_root : path
+        The local root directory that contains both the EnderChest directory, instances and servers
+    remote : str
+        The username @ hostname / IP of the remote machine, _e.g._ deck@steamdeck.local or openbagtwo@127.0.0.1
+    remote_root : path
+        The root directory on the remote machine that contains both the EnderChest directory, instances and servers
+
+    Returns
+    -------
+    str
+        rsync command to push local changes to the remote instance
+    str
+        rsync command to pull remote changes to the local instance
+
+    Notes
+    -----
+    - This method omits the header (shebang and set -e) from the generated scripts, as the intent is to allow for
+      combining multiple calls into two large scripts.
+    - This method is not designed to be safe against injection attacks--the goal is to generate **scripts** that the
+      user can then tweak and modify before calling manually.
+    - The local backup part of the script will assume that this computer's hostname is the best way to reference this
+      EnderChest installation in the remote's "other-locals" folder. That's not going to be ideal if you're managing,
+      say, multiple installations on the same computer (like, across separate user accounts?).
+    """
+    options = "-az --delete"  # TODO: make z toggleable (to support local copies); conditionally add "v"
+    exclusion_folders = (".git", "local-only", "other-locals")
+    exclusions = " ".join((f'--exclude="{folder}"' for folder in exclusion_folders))
+
+    yeet = SHARED_SYNC.format(
+        source_desc="this EnderChest",
+        destination_desc=remote.split("@")[-1],
+        options=options,
+        source=Path(local_root).absolute(),
+        destination=f"{remote}:{remote_root}",
+        exclusions=exclusions,
+    ) + LOCAL_BACKUP.format(
+        options=options,
+        local_root=Path(local_root).absolute(),
+        remote=remote,
+        remote_root=remote_root,
+        hostname=socket.gethostname(),
+    )
+
+    yoink = SHARED_SYNC.format(
+        source_desc=remote.split("@")[-1],
+        destination_desc="this EnderChest",
+        options=options,
+        source=f"{remote}:{remote_root}",
+        destination=Path(local_root).absolute(),
+        exclusions=exclusions,
+    )
+
+    return yeet, yoink
+
+
+def link_to_other_chests(
+    local_root: str | os.PathLike, *remotes: tuple[str, str | os.PathLike]
+) -> None:
+    """Generate bash scripts for syncing to EnderChest installations on other computers. These will be saved in
+    your EnderChest/local-only folder under `open.sh` (for pulling from remotes) and `close.sh` (for pushing to other
+    remotes)
+
+    Parameters
+    ----------
+    local_root : path
+        The local root directory that contains both the EnderChest directory, instances and servers
+    *remotes : tuples of (str, path)
+        The remote installations to sync with, specified as tuples of:
+          - remote_address (including username, so, like, "deck@steamdeck.local" or "openbagtwo@127.0.0.1")
+          - remote_root : the path to the remote's root directory (e.g. "~/minecraft")
+
+    Returns
+    -------
+    None
+
+    Notes
+    -----
+    - This method is designed for flexibility and transparency over robustness and ease of use. That means that
+      **you need to open the scripts this function generates** and look them over before you can actually run them. This
+      also gives you a chance add your own tweaks and customizations before first use.
+    - The remotes are assumed to be specified in **priority order** (top priority first), meaning the first remote:
+      - will be the first to receive local changes
+      - will be the first to try pulling remote changes from
+    """
+
+    open_script = HEADER
+    close_script = HEADER
+
+    for remote, remote_root in remotes:
+        yeet, yoink = _build_rsync_scripts(local_root, remote, remote_root)
+        close_script += "\n" + yeet
+        open_script += "{\n    " + "\n    ".join(yoink.split("\n")[:-1]) + "} || "
+
+    open_script += """{
+    echo "Could not pull changes from any remote EnderChests. Are you outside your local network?"
+    exit 1
+}
+"""
+
+    for name, script in (("open", open_script), ("close", close_script)):
+        script_path = contexts(local_root).local_only / f"{name}.sh"
+
+        if script_path.exists():
+            warnings.warn(f"{name.title()} script already exists. Skipping.")
+        else:
+            with script_path.open("x") as script_file:
+                script_file.write(script)

--- a/enderchest/sync.py
+++ b/enderchest/sync.py
@@ -185,7 +185,7 @@ rsync {options} \\
 
 LOCAL_BACKUP = """# backup local settings to {remote_desc}
 rsync {options} \\
-    {local_root}/EnderChest/local-only \\
+    {local_root}/EnderChest/local-only/ \\
     {remote_root}/EnderChest/other-locals/{local_desc} \\
     "$@"
 """

--- a/enderchest/sync.py
+++ b/enderchest/sync.py
@@ -1,6 +1,5 @@
 """Utilities for synchronizing chests across different computers"""
 import os
-import re
 import shlex
 import socket
 import stat
@@ -21,7 +20,7 @@ class Remote(NamedTuple):
     host : str
         The address (_e.g._ 127.0.0.1) or cname/URL (_e.g._ steamdeck.local) of the
         host you're syncing with.
-    root : path-like
+    root : path
         The root directory on the remote machine that contains all your minecraft stuff.
         Explicitly expects that the folder contains: your EnderChest folder;
         your Multi-MC-style instances folder; your servers.

--- a/enderchest/sync.py
+++ b/enderchest/sync.py
@@ -258,8 +258,8 @@ echo "Please open" $(realpath "$0")
 echo "and read through the entire script to make sure it's doing what you want,"
 echo "then delete the section marked "DELETE AFTER READING" near the top of the file."
 echo
-echo "It's also *strongly recommended* to run the commands first with
-echo "the flags: --dry-run --verbose to make absolutely sure the script is doing 
+echo "It's also *strongly recommended* to run the commands first with"
+echo "the flags: --dry-run --verbose to make absolutely sure the script is doing"
 echo "what you want before you potentially overwrite an entire file system."
 exit 1
 ########################################################################################

--- a/enderchest/sync.py
+++ b/enderchest/sync.py
@@ -40,18 +40,21 @@ class Remote(NamedTuple):
     protections you'd get out of using, say, the urllib.parse module.
     """
 
-    host: str
+    host: str | None  # intentionally not in the docstring to use None for local mirror
     root: str | os.PathLike
     username: str | None = None
     alias_: str | None = None
 
     @property
     def alias(self) -> str:
-        return self.alias_ or self.host
+        return self.alias_ or self.host or Path(self.root).name
 
     @property
     def remote_folder(self) -> str:
-        if self.username is None:
+        if not self.host:
+            # then the "remote" is actually local
+            return str(self.root)
+        if not self.username:
             url = self.host
         else:
             url = f"{self.username}@{self.host}"

--- a/enderchest/sync.py
+++ b/enderchest/sync.py
@@ -1,11 +1,10 @@
 """Utilities for synchronizing chests across different computers"""
 import os
 import socket
-from pathlib import Path
 import warnings
+from pathlib import Path
 
 from . import contexts
-
 
 HEADER = """#!/usr/bin/env bash
 set -e
@@ -73,12 +72,12 @@ def _build_rsync_scripts(
         source_desc="this EnderChest",
         destination_desc=remote.split("@")[-1],
         options=options,
-        source=Path(local_root).absolute(),
+        source=Path(local_root).resolve(),
         destination=f"{remote}:{remote_root}",
         exclusions=exclusions,
     ) + LOCAL_BACKUP.format(
         options=options,
-        local_root=Path(local_root).absolute(),
+        local_root=Path(local_root).resolve(),
         remote=remote,
         remote_root=remote_root,
         hostname=socket.gethostname(),
@@ -89,7 +88,7 @@ def _build_rsync_scripts(
         destination_desc="this EnderChest",
         options=options,
         source=f"{remote}:{remote_root}",
-        destination=Path(local_root).absolute(),
+        destination=Path(local_root).resolve(),
         exclusions=exclusions,
     )
 
@@ -132,7 +131,7 @@ def link_to_other_chests(
     for remote, remote_root in remotes:
         yeet, yoink = _build_rsync_scripts(local_root, remote, remote_root)
         close_script += "\n" + yeet
-        open_script += "{\n    " + "\n    ".join(yoink.split("\n")[:-1]) + "} || "
+        open_script += "{\n    " + "\n    ".join(yoink.split("\n")[:-1]) + "\n} || "
 
     open_script += """{
     echo "Could not pull changes from any remote EnderChests. Are you outside your local network?"

--- a/enderchest/sync.py
+++ b/enderchest/sync.py
@@ -1,11 +1,12 @@
 """Utilities for synchronizing chests across different computers"""
 import os
+import posixpath
 import shlex
 import socket
 import stat
 import warnings
 from dataclasses import dataclass, field
-from pathlib import PosixPath
+from pathlib import PurePosixPath
 from typing import NamedTuple, Sequence
 
 from . import contexts
@@ -48,7 +49,7 @@ class Remote(NamedTuple):
 
     @property
     def alias(self) -> str:
-        return self.alias_ or self.host or PosixPath(self.root).name
+        return self.alias_ or self.host or PurePosixPath(self.root).name
 
     @property
     def _encoded_root(self) -> str:
@@ -334,7 +335,7 @@ def _build_rsync_scripts(
     yoink = "".join([f"{command}\n" for command in remote.pre_open])
     yeet = "".join([f"{command}\n" for command in remote.pre_close])
 
-    local_root_path = shlex.quote(str(PosixPath(local_root).expanduser().resolve()))
+    local_root_path = shlex.quote(posixpath.abspath(posixpath.expanduser(local_root)))
 
     yeet += SHARED_SYNC.format(
         source_desc="this EnderChest",

--- a/enderchest/sync.py
+++ b/enderchest/sync.py
@@ -1,12 +1,11 @@
 """Utilities for synchronizing chests across different computers"""
 import os
-import posixpath
 import shlex
 import socket
 import stat
 import warnings
 from dataclasses import dataclass, field
-from pathlib import PurePosixPath
+from pathlib import Path
 from typing import NamedTuple, Sequence
 
 from . import contexts
@@ -49,7 +48,7 @@ class Remote(NamedTuple):
 
     @property
     def alias(self) -> str:
-        return self.alias_ or self.host or PurePosixPath(self.root).name
+        return self.alias_ or self.host or Path(self.root).name
 
     @property
     def _encoded_root(self) -> str:
@@ -335,7 +334,9 @@ def _build_rsync_scripts(
     yoink = "".join([f"{command}\n" for command in remote.pre_open])
     yeet = "".join([f"{command}\n" for command in remote.pre_close])
 
-    local_root_path = shlex.quote(posixpath.abspath(posixpath.expanduser(local_root)))
+    local_root_path = shlex.quote(
+        str(Path(local_root).expanduser().resolve().as_posix())
+    )
 
     yeet += SHARED_SYNC.format(
         source_desc="this EnderChest",

--- a/enderchest/test/conftest.py
+++ b/enderchest/test/conftest.py
@@ -36,7 +36,7 @@ def local_root(tmp_path):
             local_root / "workspace" / "neat_resource_pack" / "pack.mcmeta"
         ): '{"so": "meta"}\n',
     }
-    mod_builds_folder = local_root / "workspace" / "BestMobEver" / "build" / "libs"
+    mod_builds_folder = local_root / "workspace" / "BestModEver" / "build" / "libs"
 
     do_not_touch.update(
         {
@@ -67,9 +67,14 @@ def local_enderchest(local_root):
     do_not_touch: dict[Path, str] = {
         chest_folder / ".git" / "log": "i committed some stuff\n",
         (
-            chest_folder / "client-only" / "resourcepacks" / "stuff@axolotl"
+            chest_folder / "client-only" / "resourcepacks" / "stuff.zip@axolotl"
         ): "dfgwhgsadfhsd",
-        (chest_folder / "local-only" / "shaderpacks" / "Seuss CitH.zip.txt"): (
+        (
+            chest_folder
+            / "local-only"
+            / "shaderpacks"
+            / "Seuss CitH.zip.txt@axolotl@bee@cow"
+        ): (
             "with settings at max"
             "\nits important to note"
             "\nthe lag iks real bad"
@@ -87,7 +92,7 @@ def local_enderchest(local_root):
         (chest_folder / "global" / "mods" / "BME.jar@axolotl"): (
             local_root
             / "workspace"
-            / "BestMobEver"
+            / "BestModEver"
             / "build"
             / "libs"
             / "BME_1.19_alpha.jar"
@@ -95,7 +100,7 @@ def local_enderchest(local_root):
         (chest_folder / "global" / "mods" / "BME.jar@bee"): (
             local_root
             / "workspace"
-            / "BestMobEver"
+            / "BestModEver"
             / "build"
             / "libs"
             / "BME_1.19.1_beta.jar"
@@ -103,7 +108,7 @@ def local_enderchest(local_root):
         (chest_folder / "global" / "mods" / "BME.jar@cow"): (
             local_root
             / "workspace"
-            / "BestMobEver"
+            / "BestModEver"
             / "build"
             / "libs"
             / "BME_1.19.2_nightly.jar"

--- a/enderchest/test/conftest.py
+++ b/enderchest/test/conftest.py
@@ -86,10 +86,11 @@ def local_enderchest(local_root):
         ),
     }
 
+    (
+        chest_folder / "global" / "resourcepacks" / "neat_resource_pack@axolotl@bee"
+    ).symlink_to(local_root / "workspace" / "neat_resource_pack")
+
     symlinks: dict[Path, Path] = {  # map of links to targets
-        (
-            chest_folder / "global" / "resourcepacks" / "neat_resource_pack@axolotl@bee"
-        ): (local_root / "workspace" / "neat_resource_pack"),
         (chest_folder / "client-only" / "saves" / "olam@axolotl@bee@cow"): (
             local_root / "worlds" / "olam"
         ),

--- a/enderchest/test/conftest.py
+++ b/enderchest/test/conftest.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 import pytest
 
+from enderchest.craft import craft_ender_chest
+
 
 @pytest.fixture
 def local_root(tmp_path):
@@ -62,8 +64,10 @@ def local_enderchest(local_root):
     """An existing EnderChest directory within the local root that's got some stuff
     in it
     """
+    craft_ender_chest(local_root)
+
     chest_folder = local_root / "EnderChest"
-    chest_folder.mkdir()
+
     do_not_touch: dict[Path, str] = {
         chest_folder / ".git" / "log": "i committed some stuff\n",
         (

--- a/enderchest/test/conftest.py
+++ b/enderchest/test/conftest.py
@@ -1,4 +1,5 @@
 """Useful setup / teardown fixtures"""
+import importlib.resources
 from pathlib import Path
 
 import pytest
@@ -135,3 +136,11 @@ def local_enderchest(local_root):
 
     for path, contents in do_not_touch.items():
         assert path.read_text() == contents
+
+
+@pytest.fixture
+def example_config_path():
+    with importlib.resources.path(
+        "enderchest.test", "example_configs"
+    ) as example_configs:
+        yield example_configs / "example.cfg"

--- a/enderchest/test/conftest.py
+++ b/enderchest/test/conftest.py
@@ -1,0 +1,127 @@
+"""Useful setup / teardown fixtures"""
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def local_root(tmp_path):
+    """A temporary local minecraft root folder (initially instantiated without an
+    EnderChest)"""
+    local_root = tmp_path / "minecraft"
+    (local_root / "instances").mkdir(parents=True)
+    (local_root / "servers").mkdir(parents=True)
+    (local_root / "worlds").mkdir(
+        parents=True
+    )  # makes sense to store the actual saves outside the EnderChest folder
+    (local_root / "workspace").mkdir(
+        parents=True
+    )  # generic other stuff that exists in the minecraft root
+
+    do_not_touch: dict[Path, str] = {
+        local_root / "README.md": "#Hello\n\nI'm your friendly neighborhood README!\n",
+        (
+            local_root / "workspace" / "cool_project.py"
+        ): 'print("Gosh, I hope no one deletes or overwrites me")\n',
+        (
+            local_root
+            / "instances"
+            / "worlds_best_modpack"
+            / ".minecraft"
+            / "mods"
+            / "worldsbestmod.jar"
+        ): "beepboop",
+        local_root / "worlds" / "olam" / "level.dat": "level dis\n",
+        (
+            local_root / "workspace" / "neat_resource_pack" / "pack.mcmeta"
+        ): '{"so": "meta"}\n',
+    }
+    mod_builds_folder = local_root / "workspace" / "BestMobEver" / "build" / "libs"
+
+    do_not_touch.update(
+        {
+            mod_builds_folder / "BME_1.19_alpha.jar": "alfalfa",
+            mod_builds_folder / "BME_1.19.1_beta.jar": "beater",
+            mod_builds_folder / "BME_1.19.2_nightly.jar": "can i get a bat",
+        }
+    )
+
+    for path, contents in do_not_touch.items():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(contents)
+
+    yield local_root
+
+    # check on teardown that all those "do_not_touch" files are untouched
+    for path, contents in do_not_touch.items():
+        assert path.read_text() == contents
+
+
+@pytest.fixture
+def local_enderchest(local_root):
+    """An existing EnderChest directory within the local root that's got some stuff
+    in it
+    """
+    chest_folder = local_root / "EnderChest"
+    chest_folder.mkdir()
+    do_not_touch: dict[Path, str] = {
+        chest_folder / ".git" / "log": "i committed some stuff\n",
+        (
+            chest_folder / "client-only" / "resourcepacks" / "stuff@axolotl"
+        ): "dfgwhgsadfhsd",
+        (chest_folder / "local-only" / "shaderpacks" / "Seuss CitH.zip.txt"): (
+            "with settings at max"
+            "\nits important to note"
+            "\nthe lag iks real bad"
+            "\nbut just look at that goat!"
+        ),
+    }
+
+    symlinks: dict[Path, Path] = {  # map of links to targets
+        (
+            chest_folder / "global" / "resourcepacks" / "neat_resource_pack@axolotl@bee"
+        ): (local_root / "workspace" / "neat_resource_pack"),
+        (chest_folder / "client-only" / "saves" / "olam@axolotl@bee@cow"): (
+            local_root / "worlds" / "olam"
+        ),
+        (chest_folder / "global" / "mods" / "BME.jar@axolotl"): (
+            local_root
+            / "workspace"
+            / "BestMobEver"
+            / "build"
+            / "libs"
+            / "BME_1.19_alpha.jar"
+        ),
+        (chest_folder / "global" / "mods" / "BME.jar@bee"): (
+            local_root
+            / "workspace"
+            / "BestMobEver"
+            / "build"
+            / "libs"
+            / "BME_1.19.1_beta.jar"
+        ),
+        (chest_folder / "global" / "mods" / "BME.jar@cow"): (
+            local_root
+            / "workspace"
+            / "BestMobEver"
+            / "build"
+            / "libs"
+            / "BME_1.19.2_nightly.jar"
+        ),
+    }
+
+    for path, contents in do_not_touch.items():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(contents)
+
+    for link_path, target in symlinks.items():
+        link_path.parent.mkdir(parents=True, exist_ok=True)
+        link_path.symlink_to(target)
+
+    yield chest_folder
+
+    for link_path, target in symlinks.items():
+        assert link_path.resolve() == target.resolve()
+
+    for path, contents in do_not_touch.items():
+        assert path.read_text() == contents

--- a/enderchest/test/conftest.py
+++ b/enderchest/test/conftest.py
@@ -63,9 +63,9 @@ def local_root(tmp_path):
 @pytest.fixture
 def local_enderchest(local_root):
     """An existing EnderChest directory within the local root that's got some stuff
-    in it
+    in it (but critically no sync scripts)
     """
-    craft_ender_chest(local_root)
+    craft_ender_chest(local_root, craft_folders_only=True)
 
     chest_folder = local_root / "EnderChest"
 
@@ -82,7 +82,7 @@ def local_enderchest(local_root):
         ): (
             "with settings at max"
             "\nits important to note"
-            "\nthe lag iks real bad"
+            "\nthe lag is real bad"
             "\nbut just look at that goat!"
         ),
     }

--- a/enderchest/test/example_configs/example.cfg
+++ b/enderchest/test/example_configs/example.cfg
@@ -1,0 +1,30 @@
+[local]
+name = battlestar
+root = /main/minecraft
+
+[options]
+post_open = cd /main/minecraft/EnderChest && git add . && git commit -m "Pulled changes from remotes"
+post_close = "cd /main/minecraft/EnderChest && git add . && git commit -m \"Pushing out local changes\""
+
+# remotes
+
+[couch-potato]
+address=192.168.0.101
+root = ~/Games/minecraft/
+post_open = [
+   "lectern checkout $active_world"
+    ]
+pre_close = [
+    "lectern return $active_world"
+    ]
+
+[steam-deck.local]
+username = deck
+root = ~/minecraft
+timeout=1
+
+[nuggets_laptop]
+user = nugget
+root = ~/Games/minecraft
+timeout=1
+parental_mode = True

--- a/enderchest/test/test_cli.py
+++ b/enderchest/test/test_cli.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 import enderchest
-from enderchest import cli
+from enderchest import cli, place
 from enderchest.sync import Remote
 
 
@@ -146,6 +146,20 @@ class TestPlace:
         _, root, _ = cli.parse_args(["enderchest", "place"])
         assert root == Path("~~dummy~~")
 
+    def test_dispatches_to_place_method(self):
+        action, _, _ = cli.parse_args(["enderchest", "place"])
+        assert action == place.place_enderchest
+
     def test_first_argument_is_root(self):
         _, root, _ = cli.parse_args(["enderchest", "place", "/home"])
         assert root == Path("/home")
+
+    @pytest.mark.parametrize("flag", ("-k", "--keep-broken"))
+    def test_keep_broken_links(self, monkeypatch, flag):
+        def mock_place(path, cleanup):
+            assert not cleanup
+
+        monkeypatch.setattr(cli, "place_enderchest", mock_place)
+
+        action, root, options = cli.parse_args(["enderchest", "place", "/home"])
+        action(root, **options)

--- a/enderchest/test/test_cli.py
+++ b/enderchest/test/test_cli.py
@@ -6,6 +6,7 @@ import pytest
 
 import enderchest
 from enderchest import cli
+from enderchest.sync import Remote
 
 
 class TestHelp:
@@ -42,20 +43,101 @@ class TestCraft:
         _, root, _ = cli.parse_args(["enderchest", "craft"])
         assert root == Path("~~dummy~~")
 
-    def test_default_dispatch_is_to_non_config_craft(self, monkeypatch):
+    def test_default_dispatch_is_to_non_config_craft(self, monkeypatch, capsys):
         def wrong_method(*args, **kwargs):
             assert False, "Wrong method"
 
         def correct_method(*args, **kwargs):
-            pass
+            print("You chose correctly")
 
         monkeypatch.setattr(cli, "craft_ender_chest_from_config", wrong_method)
         monkeypatch.setattr(cli, "craft_ender_chest", correct_method)
-        action, _, _ = cli.parse_args(["enderchest", "craft"])
+        action, root, _ = cli.parse_args(["enderchest", "craft"])
+        action(root)
+        assert capsys.readouterr().out == "You chose correctly\n"
 
-    def test_first_argument_is_root(self):
+    def test_first_argument_is_root(self, capsys):
         _, root, _ = cli.parse_args(["enderchest", "craft", "/home"])
         assert root == Path("/home")
+
+    @pytest.mark.parametrize("config_flag", ("-f", "--file"))
+    def test_passing_a_config_switches_to_the_config_craft(
+        self, monkeypatch, capsys, config_flag
+    ):
+        def wrong_method(*args, **kwargs):
+            assert False, "Wrong method"
+
+        def correct_method(path):
+            print(path)
+
+        monkeypatch.setattr(cli, "craft_ender_chest_from_config", correct_method)
+        monkeypatch.setattr(cli, "craft_ender_chest", wrong_method)
+        action, root, options = cli.parse_args(
+            ["enderchest", "craft", config_flag, "blah.cfg"]
+        )
+
+        action(root, **options)
+        assert capsys.readouterr().out == "blah.cfg\n"
+
+    @pytest.mark.parametrize("remote_flag", ("-r", "--remote"))
+    def test_passing_in_a_single_remote(self, monkeypatch, remote_flag):
+
+        remotes = []
+
+        def wrong_method(*args, **kwargs):
+            assert False, "Wrong method"
+
+        def correct_method(path, *parsed_remotes, **kwargs):
+            remotes.extend(parsed_remotes)
+
+        monkeypatch.setattr(cli, "craft_ender_chest_from_config", wrong_method)
+        monkeypatch.setattr(cli, "craft_ender_chest", correct_method)
+
+        action, root, options = cli.parse_args(
+            ["enderchest", "craft", remote_flag, "openbagtwo@mirror:~/minecraft"]
+        )
+        action(root, **options)
+
+        assert remotes == [Remote("mirror", "~/minecraft", "openbagtwo")]
+
+    @pytest.mark.parametrize("remote_flag_1", ("-r", "--remote"))
+    @pytest.mark.parametrize("remote_flag_2", ("-r", "--remote"))
+    @pytest.mark.parametrize("remote_flag_3", ("-r", "--remote"))
+    def test_passing_in_a_multiple_remotes_plus_other_kwargs(
+        self, monkeypatch, remote_flag_1, remote_flag_2, remote_flag_3
+    ):
+        remotes = []
+
+        def wrong_method(*args, **kwargs):
+            assert False, "Wrong method"
+
+        def correct_method(path, *parsed_remotes, **kwargs):
+            assert kwargs["overwrite"]
+            remotes.extend(parsed_remotes)
+
+        monkeypatch.setattr(cli, "craft_ender_chest_from_config", wrong_method)
+        monkeypatch.setattr(cli, "craft_ender_chest", correct_method)
+
+        action, root, options = cli.parse_args(
+            [
+                "enderchest",
+                "craft",
+                remote_flag_1,
+                "openbagtwo@mirror:~/minecraft",
+                remote_flag_2,
+                "~/minecraft2",
+                "--overwrite",
+                remote_flag_3,
+                "pie:/opt/run/minecraft",
+            ]
+        )
+        action(root, **options)
+
+        assert remotes == [
+            Remote("mirror", "~/minecraft", "openbagtwo"),
+            Remote(None, "~/minecraft2"),
+            Remote("pie", "/opt/run/minecraft"),
+        ]
 
 
 class TestPlace:

--- a/enderchest/test/test_cli.py
+++ b/enderchest/test/test_cli.py
@@ -1,0 +1,69 @@
+"""Test the command-line interface"""
+import os
+from pathlib import Path
+
+import pytest
+
+import enderchest
+from enderchest import cli
+
+
+class TestHelp:
+    @pytest.mark.parametrize("help_flag", ("-h", "--help"))
+    def test_help_displays_version(self, capsys, help_flag):
+        with pytest.raises(SystemExit):
+            cli.parse_args(["enderchest", help_flag])
+
+        assert enderchest.__version__ in capsys.readouterr().out
+
+    @pytest.mark.parametrize("help_flag", ("-h", "--help"))
+    def test_help_ignores_arguments_that_follow(self, capsys, help_flag):
+        with pytest.raises(SystemExit):
+            cli.parse_args(["enderchest", help_flag, "foo"])
+
+        assert "foo" not in capsys.readouterr().out
+        assert "foo" not in capsys.readouterr().err
+
+    @pytest.mark.parametrize("help_flag", ("-h", "--help"))
+    @pytest.mark.parametrize("action, description, method", cli.ACTIONS)
+    def test_help_gives_action_specific_help(
+        self, capsys, help_flag, action, description, method
+    ):
+        with pytest.raises(SystemExit):
+            cli.parse_args(["enderchest", action, help_flag])
+
+        stdout = capsys.readouterr().out
+        assert f"enderchest {action} [-h]" in stdout
+
+
+class TestCraft:
+    def test_default_root_is_cwd(self, monkeypatch):
+        monkeypatch.setattr(os, "getcwd", lambda: "~~dummy~~")
+        _, root, _ = cli.parse_args(["enderchest", "craft"])
+        assert root == Path("~~dummy~~")
+
+    def test_default_dispatch_is_to_non_config_craft(self, monkeypatch):
+        def wrong_method(*args, **kwargs):
+            assert False, "Wrong method"
+
+        def correct_method(*args, **kwargs):
+            pass
+
+        monkeypatch.setattr(cli, "craft_ender_chest_from_config", wrong_method)
+        monkeypatch.setattr(cli, "craft_ender_chest", correct_method)
+        action, _, _ = cli.parse_args(["enderchest", "craft"])
+
+    def test_first_argument_is_root(self):
+        _, root, _ = cli.parse_args(["enderchest", "craft", "/home"])
+        assert root == Path("/home")
+
+
+class TestPlace:
+    def test_default_root_is_cwd(self, monkeypatch):
+        monkeypatch.setattr(os, "getcwd", lambda: "~~dummy~~")
+        _, root, _ = cli.parse_args(["enderchest", "place"])
+        assert root == Path("~~dummy~~")
+
+    def test_first_argument_is_root(self):
+        _, root, _ = cli.parse_args(["enderchest", "place", "/home"])
+        assert root == Path("/home")

--- a/enderchest/test/test_config.py
+++ b/enderchest/test/test_config.py
@@ -2,7 +2,7 @@
 import itertools
 import warnings
 from configparser import ConfigParser, ParsingError
-from pathlib import Path
+from pathlib import PurePosixPath
 
 import pytest
 
@@ -129,7 +129,7 @@ blah=blah
             example_config_parser["couch-potato"]
         ).remote
 
-        assert remote.root == Path("~/Games/minecraft")
+        assert remote.root == PurePosixPath("~/Games/minecraft")
 
     def test_host_is_alias_by_default(self, example_config_parser):
         remote = config._parse_remote_section(
@@ -330,7 +330,7 @@ blah=blah
     def test_parsing_root(self, example_config_parser):
         local_root, _ = config._parse_local_section(example_config_parser["local"])
 
-        assert local_root == Path("/main/minecraft")
+        assert local_root == PurePosixPath("/main/minecraft")
 
     def test_name_is_not_required(self):
         parser = ConfigParser()
@@ -419,7 +419,7 @@ overwrite_scripts=yes
 root=~/minecraft
 """
         expected = config.Config(
-            Path("~/minecraft"),
+            PurePosixPath("~/minecraft"),
             [RemoteSync(Remote("mirror", "~/minecraft"))],
             craft_options={"overwrite": True},
         )
@@ -437,7 +437,7 @@ overwrite_scripts=yes
 root=~/minecraft
 """
         expected = config.Config(
-            Path("~/minecraft"),
+            PurePosixPath("~/minecraft"),
             [RemoteSync(Remote("mirror", "~/minecraft"))],
             craft_options={"overwrite": True},
         )
@@ -451,7 +451,7 @@ root=~/minecraft
 root=~/minecraft
 """
         expected = config.Config(
-            Path("~/minecraft"),
+            PurePosixPath("~/minecraft"),
             [],
         )
         parsed_config = config.parse_config(local_only_config)
@@ -525,7 +525,7 @@ overwrite_scripts=no
 
     def test_parse_config_from_file(self, example_config_path):
         expected = config.Config(
-            Path("/main/minecraft"),
+            PurePosixPath("/main/minecraft"),
             (
                 RemoteSync(
                     Remote("192.168.0.101", "~/Games/minecraft", alias_="couch-potato"),

--- a/enderchest/test/test_config.py
+++ b/enderchest/test/test_config.py
@@ -563,7 +563,6 @@ overwrite_scripts=no
             original_config._config.write(f)
 
         deserialized_config = config.parse_config_file(write_path)
-
         assert original_config._asdict == deserialized_config._asdict
 
 

--- a/enderchest/test/test_config.py
+++ b/enderchest/test/test_config.py
@@ -129,7 +129,7 @@ blah=blah
             example_config_parser["couch-potato"]
         ).remote
 
-        assert remote.root == PurePosixPath("~/Games/minecraft")
+        assert remote.root == "~/Games/minecraft"
 
     def test_host_is_alias_by_default(self, example_config_parser):
         remote = config._parse_remote_section(
@@ -330,7 +330,7 @@ blah=blah
     def test_parsing_root(self, example_config_parser):
         local_root, _ = config._parse_local_section(example_config_parser["local"])
 
-        assert local_root == PurePosixPath("/main/minecraft")
+        assert local_root == "/main/minecraft"
 
     def test_name_is_not_required(self):
         parser = ConfigParser()

--- a/enderchest/test/test_config.py
+++ b/enderchest/test/test_config.py
@@ -401,4 +401,9 @@ post_close=[
         }
 
 
+# TODO: test top-level conf-readers
+#       (once I change the config format to keep wrapper commands with the remotes)
+
+# TODO: test serializing
+
 # TODO: test for TOML compatibility

--- a/enderchest/test/test_config.py
+++ b/enderchest/test/test_config.py
@@ -275,7 +275,7 @@ generate_runnable_scripts={magic_words}
     def test_no_scripts_overwrite_by_default(self):
         parser = ConfigParser()
         parser.read_string(
-            f"""
+            """
 [options]
 dephlogisticate=True
 """
@@ -303,7 +303,7 @@ overwrite_scripts={entry}
     def test_non_boolean_overwrite_value_raises_parsing_error(self):
         parser = ConfigParser()
         parser.read_string(
-            f"""
+            """
 [options]
 overwrite_scripts="okay"
 """
@@ -359,7 +359,7 @@ root=.
     def test_conflicting_names_gives_error(self):
         parser = ConfigParser()
         parser.read_string(
-            f"""
+            """
 [local]
 name=Antar
 alias=OpenBagTwo
@@ -416,7 +416,7 @@ root=~/minecraft
 overwrite_scripts=yes
 
 [mirror]
-root=~/minecraft        
+root=~/minecraft
 """
         expected = config.Config(
             Path("~/minecraft"),
@@ -434,7 +434,7 @@ root=~/minecraft
 overwrite_scripts=yes
 
 [mirror]
-root=~/minecraft        
+root=~/minecraft
 """
         expected = config.Config(
             Path("~/minecraft"),
@@ -448,7 +448,7 @@ root=~/minecraft
     def test_you_dont_technically_need_any_remotes(self):
         local_only_config = """
 [local]
-root=~/minecraft    
+root=~/minecraft
 """
         expected = config.Config(
             Path("~/minecraft"),
@@ -462,9 +462,9 @@ root=~/minecraft
         nonlocal_config = """
 [options]
 blah=True
-        
+
 [mirror]
-root=~/minecraft    
+root=~/minecraft
 """
         with pytest.raises(ParsingError, match="local"):
             config.parse_config(nonlocal_config)
@@ -482,7 +482,7 @@ root=~/minecraft
 
 [mirror]
 host=mirror
-root=/on/the/wall 
+root=/on/the/wall
 """
         with pytest.raises(Exception, match="mirror"):
             config.parse_config(dupe_config)
@@ -500,7 +500,7 @@ pre_close = [
     "echo 4"
     ]
 post_open = "echo 5"
-             
+
 """
         parsed_config = config.parse_config(split_wrapper_config)
         assert (

--- a/enderchest/test/test_config.py
+++ b/enderchest/test/test_config.py
@@ -1,0 +1,404 @@
+"""Test the config parser"""
+import itertools
+import warnings
+from configparser import ConfigParser, ParsingError
+from pathlib import Path
+
+import pytest
+
+from enderchest import config
+
+
+@pytest.fixture
+def example_config_parser(example_config_path):
+    parser = ConfigParser()
+    with example_config_path.open() as config_file:
+        parser.read_file(config_file)
+    yield parser
+
+
+class TestParseString:
+    @pytest.mark.parametrize("entry", ("'hello'", '"hello"'))
+    def test_strip_simple_quotes(self, entry):
+        assert config._parse_string(entry) == "hello"
+
+    @pytest.mark.parametrize("quote_char", ("'''", '"""'))
+    def test_strip_multiline_quotes(self, quote_char):
+        entry = f"{quote_char}\nhello\n{quote_char}"
+        assert config._parse_string(entry) == "\nhello\n"  # read: doesn't strip
+
+    def test_unquoted_string_is_left_alone(self):
+        entry = 'echo "hello"'
+        assert config._parse_string(entry) == entry
+
+    def test_string_with_mismatching_quotes_is_left_alone(self):
+        entry = "'what I'm trying to say is\""
+        assert config._parse_string(entry) == entry
+
+
+class TestParsePreOrPostCommandEntry:
+    def test_parsing_a_simple_string(self):
+        assert config._parse_pre_or_post_command_entry("echo hello") == ["echo hello"]
+
+    def test_parsing_a_single_line_list_of_commands(self):
+        assert config._parse_pre_or_post_command_entry(
+            '["echo hello", "echo what a lovely day"]'
+        ) == [
+            "echo hello",
+            "echo what a lovely day",
+        ]
+
+    def test_parsing_a_multiline_line_list_of_commands(self):
+        # TODO: put a note in a doc somewhere about Windows and backslashes
+        assert (
+            config._parse_pre_or_post_command_entry(
+                r"""[
+    "C:\\DOS",
+    "C:\\DOS\\run",
+    "run DOS\\run"
+]
+"""
+            )
+            == [
+                r"C:\DOS",
+                r"C:\DOS\run",
+                r"run DOS\run",
+            ]
+        )
+
+
+class TestParsePreAndPostCommands:
+    def test_section_with_no_wrapper_commands_still_gives_full_dict(
+        self, example_config_parser
+    ):
+        assert config._parse_pre_and_post_commands(
+            example_config_parser["nuggets_laptop"]
+        ) == {"pre_open": [], "pre_close": [], "post_open": [], "post_close": []}
+
+    def test_parsing_section_with_unquoted_command(self, example_config_parser):
+        assert config._parse_pre_and_post_commands(example_config_parser["options"])[
+            "post_open"
+        ] == [
+            "cd /main/minecraft/EnderChest"
+            " && git add ."
+            ' && git commit -m "Pulled changes from remotes"'
+        ]
+
+    def test_parsing_section_with_quoted_command(self, example_config_parser):
+        assert config._parse_pre_and_post_commands(example_config_parser["options"])[
+            "post_close"
+        ] == [
+            "cd /main/minecraft/EnderChest"
+            " && git add ."
+            ' && git commit -m "Pushing out local changes"'
+        ]
+
+    def test_parsing_section_with_multiline_commands(self, example_config_parser):
+        assert config._parse_pre_and_post_commands(
+            example_config_parser["couch-potato"]
+        ) == {
+            "pre_open": [],
+            "pre_close": ["lectern return $active_world"],
+            "post_open": ["lectern checkout $active_world"],
+            "post_close": [],
+        }
+
+
+class TestParseRemoteSection:
+    @pytest.mark.parametrize(
+        "alias", ("couch-potato", "steam-deck.local", "nuggets_laptop")
+    )
+    def test_alias_comes_from_the_section_header(self, example_config_parser, alias):
+        _, remote, _ = config._parse_remote_section(example_config_parser[alias])
+        assert remote.alias == alias
+
+    def test_root_is_required(self):
+        parser = ConfigParser()
+        parser.read_string(
+            """
+[floating]
+blah=blah
+"""
+        )
+        with pytest.raises(ParsingError, match=r"(floating(.*)root|root(.*)floating)"):
+            config._parse_remote_section(parser["floating"])
+
+    def test_parsing_root(self, example_config_parser):
+        _, remote, _ = config._parse_remote_section(
+            example_config_parser["couch-potato"]
+        )
+
+        assert remote.root == Path("~/Games/minecraft")
+
+    def test_host_is_alias_by_default(self, example_config_parser):
+        _, remote, _ = config._parse_remote_section(
+            example_config_parser["steam-deck.local"]
+        )
+        assert remote.host == "steam-deck.local"
+
+    def test_setting_host_explicitly(self, example_config_parser):
+        _, remote, _ = config._parse_remote_section(
+            example_config_parser["couch-potato"]
+        )
+        assert remote.host == "192.168.0.101"
+
+    def test_conflicting_hosts_raises_error(self):
+        parser = ConfigParser()
+        parser.read_string(
+            """
+[banjo_man]  # you can't tie down a banjo man
+hostname=Ms. Bliss
+address=on the road
+root=/cul/de/sac
+"""
+        )
+
+        # I don't care about the order, and I'm too lazy and typo-prone to
+        # enumerate all 3! permutations by hand
+        patterns: list[str] = []
+        for permutation in itertools.permutations(("banjo_man", "conflicting", "host")):
+            patterns.append(r"(.*)".join(permutation))
+        with pytest.raises(ParsingError, match=rf'({"|".join(patterns)})'):
+            config._parse_remote_section(parser["banjo_man"])
+
+    def test_no_username_by_default(self, example_config_parser):
+        _, remote, _ = config._parse_remote_section(
+            example_config_parser["couch-potato"]
+        )
+        assert remote.remote_folder == "192.168.0.101:~/Games/minecraft"
+
+    @pytest.mark.parametrize(
+        "keyword, alias, expected",
+        (
+            ("username", "steam-deck.local", "deck"),
+            ("user", "nuggets_laptop", "nugget"),
+        ),
+    )
+    def test_setting_username(self, example_config_parser, keyword, alias, expected):
+        _, remote, _ = config._parse_remote_section(example_config_parser[alias])
+        assert remote.remote_folder.startswith(f"{expected}@")
+
+    def test_conflicting_username_raises_error(self):
+        parser = ConfigParser()
+        parser.read_string(
+            """
+[steve miller band]
+root=les/paul
+user=space cowboy
+username=Maurice (wah wah)
+"""
+        )
+
+        # I don't care about the order, and I'm too lazy and typo-prone to
+        # enumerate all 3! permutations by hand
+        patterns: list[str] = []
+        for permutation in itertools.permutations(
+            ("steve miller band", "conflicting", "user")
+        ):
+            patterns.append(r"(.*)".join(permutation))
+        with pytest.raises(ParsingError, match=rf'({"|".join(patterns)})'):
+            config._parse_remote_section(parser["steve miller band"])
+
+    def test_remote_parsing_grabs_wrapper_commands(self, example_config_parser):
+        (
+            (pre_open, pre_close),
+            _,
+            (post_open, post_close),
+        ) = config._parse_remote_section(example_config_parser["couch-potato"])
+
+        assert (pre_open, pre_close, post_open, post_close) == (
+            [],
+            ["lectern return $active_world"],
+            ["lectern checkout $active_world"],
+            [],
+        )
+
+
+class TestParseOptions:
+    @pytest.fixture(autouse=True)
+    def raise_uncaught_warnings_as_errors(self):
+        with warnings.catch_warnings(record=True) as warnings_log:
+            warnings.simplefilter("always")
+            yield
+        assert [warning.message for warning in warnings_log] == []
+
+    @pytest.mark.parametrize("false", ("False", "false", "no", "0"))
+    def test_explicitly_enabling_scare_warnings(self, false):
+        parser = ConfigParser()
+        parser.read_string(
+            f"""
+[options]
+generate_runnable_scripts={false}
+"""
+        )
+        assert (
+            config._parse_options_section(parser["options"])["omit_scare_warnings"]
+            is False
+        )
+
+    @pytest.mark.parametrize("true", ("True", "1", "yes", "i am sure"))
+    def test_disabling_scare_warnings_without_saying_the_magic_words_is_ignored(
+        self, true
+    ):
+        parser = ConfigParser()
+        parser.read_string(
+            f"""
+[options]
+generate_runnable_scripts={true}
+"""
+        )
+        with pytest.warns(UserWarning, match="risk acknowledgement"):
+            options = config._parse_options_section(parser["options"])
+        assert options["omit_scare_warnings"] is False
+
+    @pytest.mark.parametrize("with_quotes", (True, False))
+    def test_disabling_scare_warnings_with_the_magic_words(self, with_quotes):
+        magic_words = "I acknowledge that this is dangerous"
+        if with_quotes:
+            magic_words = f'"{magic_words}"'
+        parser = ConfigParser()
+        parser.read_string(
+            f"""
+[options]
+generate_runnable_scripts={magic_words}
+"""
+        )
+        assert (
+            config._parse_options_section(parser["options"])["omit_scare_warnings"]
+            is True
+        )
+
+    def test_no_scripts_overwrite_by_default(self):
+        parser = ConfigParser()
+        parser.read_string(
+            f"""
+[options]
+dephlogisticate=True
+"""
+        )
+        options = config._parse_options_section(parser["options"])
+        assert "overwrite" not in options
+
+    @pytest.mark.parametrize(
+        "entry, expected",
+        (
+            *((true, True) for true in ("True", "true", "1", "yes")),
+            *((false, False) for false in ("False", "false", "no", "0")),
+        ),
+    )
+    def test_explicitly_setting_scripts_overwrite_option(self, entry, expected):
+        parser = ConfigParser()
+        parser.read_string(
+            f"""
+[options]
+overwrite_scripts={entry}
+"""
+        )
+        assert config._parse_options_section(parser["options"])["overwrite"] is expected
+
+    def test_non_boolean_overwrite_value_raises_parsing_error(self):
+        parser = ConfigParser()
+        parser.read_string(
+            f"""
+[options]
+overwrite_scripts="okay"
+"""
+        )
+        with pytest.raises(
+            ParsingError,
+            match=r'(overwrite_scripts(.*)"okay"|"okay"(.*)overwrite_scripts)',
+        ):
+            config._parse_options_section(parser["options"])
+
+
+class TestParseLocalSection:
+    def test_root_is_required(self):
+        parser = ConfigParser()
+        parser.read_string(
+            """
+[local]
+blah=blah
+"""
+        )
+        with pytest.raises(ParsingError, match=r"(local(.*)root|root(.*)local)"):
+            config._parse_local_section(parser["local"])
+
+    def test_parsing_root(self, example_config_parser):
+        local_root, _ = config._parse_local_section(example_config_parser["local"])
+
+        assert local_root == Path("/main/minecraft")
+
+    def test_name_is_not_required(self):
+        parser = ConfigParser()
+        parser.read_string(
+            """
+[local]
+root=.
+"""
+        )
+        _, options = config._parse_local_section(parser["local"])
+        assert options["local_alias"] is None
+
+    @pytest.mark.parametrize("keyword", ("name", "alias"))
+    def test_explicitly_setting_name(self, keyword):
+        parser = ConfigParser()
+        parser.read_string(
+            f"""
+[local]
+{keyword}=me
+root=.
+"""
+        )
+        _, options = config._parse_local_section(parser["local"])
+        assert options["local_alias"] == "me"
+
+    def test_conflicting_names_gives_error(self):
+        parser = ConfigParser()
+        parser.read_string(
+            f"""
+[local]
+name=Antar
+alias=OpenBagTwo
+root=.
+"""
+        )
+        # I don't care about the order, and I'm too lazy and typo-prone to
+        # enumerate all 3! permutations by hand
+        patterns: list[str] = []
+        for permutation in itertools.permutations(("local", "conflicting", "alias")):
+            patterns.append(r"(.*)".join(permutation))
+        with pytest.raises(ParsingError, match=rf'({"|".join(patterns)})'):
+            config._parse_local_section(parser["local"])
+
+    def test_options_can_also_be_provided_in_local_section(self):
+        parser = ConfigParser()
+        parser.read_string(
+            """
+[local]
+name=OpenBagTwo
+root=.
+overwrite_scripts=True
+generate_runnable_scripts=no
+pre_open=playsound minecraft:door_open
+post_close=[
+    "stuff in_drawer",
+    "goto bed"
+    ]
+"""
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            _, options = config._parse_local_section(parser["local"])
+
+        assert options == {
+            "local_alias": "OpenBagTwo",
+            "overwrite": True,
+            "omit_scare_warnings": False,
+            "pre_open": ["playsound minecraft:door_open"],
+            "pre_close": [],
+            "post_open": [],
+            "post_close": ["stuff in_drawer", "goto bed"],
+        }
+
+
+# TODO: test for TOML compatibility

--- a/enderchest/test/test_config.py
+++ b/enderchest/test/test_config.py
@@ -564,6 +564,3 @@ overwrite_scripts=no
 
         deserialized_config = config.parse_config_file(write_path)
         assert original_config._asdict == deserialized_config._asdict
-
-
-# TODO: test for TOML compatibility

--- a/enderchest/test/test_craft.py
+++ b/enderchest/test/test_craft.py
@@ -1,0 +1,32 @@
+"""Test functionality around creating the EnderChest folder"""
+from enderchest import craft
+
+
+class TestCraftEnderChest:
+    def test_new_ender_chest_has_correct_top_level_structure(self, local_root):
+        assert not (local_root / "EnderCheest").exists()
+
+        craft.craft_ender_chest(local_root)
+
+        assert sorted(
+            (path.name for path in (local_root / "EnderChest").glob("*"))
+        ) == [
+            "client-only",
+            "global",
+            "local-only",
+            "other-locals",
+            "server-only",
+        ]
+
+    def test_crafting_a_chest_where_theres_already_a_chest_is_fine(
+        self, local_enderchest
+    ):
+        craft.craft_ender_chest(local_enderchest / "..")
+
+        assert {
+            "client-only",
+            "global",
+            "local-only",
+            "other-locals",
+            "server-only",
+        }.issubset((path.name for path in local_enderchest.glob("*")))

--- a/enderchest/test/test_place.py
+++ b/enderchest/test/test_place.py
@@ -1,0 +1,107 @@
+"""Test functionality around linking instances"""
+from pathlib import Path
+
+import pytest
+
+from enderchest import place
+
+
+class TestLinkInstance:
+    @pytest.fixture
+    def aether_dot_zip(self, tmp_path):
+        a_backup = tmp_path / "aether.zip"
+        a_backup.write_bytes(b"beepboop")
+        yield a_backup
+
+    @pytest.fixture
+    def beether_dot_zip(self, tmp_path):
+        another_backup = tmp_path / "beether.zip"
+        another_backup.write_bytes(b"buzzbuzz")
+        yield another_backup
+
+    def test_link_instance_skips_nonexistent_instances_by_default(
+        self, tmp_path, aether_dot_zip
+    ):
+        place.link_instance(
+            Path("backups") / "aether.zip", tmp_path / "idonotexist", aether_dot_zip
+        )
+
+        assert not (tmp_path / "idonotexist").exists()
+
+    def test_link_instance_will_create_folders_inside_of_existing_instances(
+        self, tmp_path, aether_dot_zip
+    ):
+        (tmp_path / "i_sort_of_exist" / ".minecraft" / "backups").mkdir(parents=True)
+        place.link_instance(
+            Path("backups") / "aether.zip",
+            tmp_path / "i_sort_of_exist",
+            aether_dot_zip,
+        )
+
+        assert (
+            tmp_path / "i_sort_of_exist" / ".minecraft" / "backups" / "aether.zip"
+        ).exists()
+
+    def test_link_instance_can_be_made_to_create_instance_folders(
+        self, tmp_path, aether_dot_zip
+    ):
+
+        place.link_instance(
+            Path("backups") / "aether.zip",
+            tmp_path / "makeme",
+            aether_dot_zip,
+            check_exists=False,
+        )
+
+        assert (tmp_path / "makeme" / ".minecraft" / "backups" / "aether.zip").exists()
+
+    @pytest.mark.parametrize("check_exists", (True, False))
+    def test_link_instance_will_overwrite_existing_links(
+        self, check_exists, tmp_path, aether_dot_zip, beether_dot_zip
+    ):
+        beether_contents = beether_dot_zip.read_bytes()
+
+        (tmp_path / "i_exist" / ".minecraft" / "backups").mkdir(parents=True)
+        (tmp_path / "i_exist" / ".minecraft" / "backups" / "aether.zip").symlink_to(
+            beether_dot_zip
+        )
+
+        place.link_instance(
+            Path("backups") / "aether.zip",
+            tmp_path / "i_exist",
+            aether_dot_zip,
+            check_exists=check_exists,
+        )
+
+        assert (
+            tmp_path / "i_exist" / ".minecraft" / "backups" / "aether.zip"
+        ).read_bytes() == aether_dot_zip.read_bytes()
+
+        # assert that the original is unchanged
+        assert beether_dot_zip.read_bytes() == beether_contents
+
+    @pytest.mark.parametrize("check_exists", (True, False))
+    def test_link_instance_will_not_overwrite_an_actual_file(
+        self, check_exists, tmp_path, aether_dot_zip, beether_dot_zip
+    ):
+        beether_contents = beether_dot_zip.read_bytes()
+
+        (tmp_path / "i_exist" / ".minecraft" / "backups").mkdir(parents=True)
+        beether_dot_zip.rename(
+            tmp_path / "i_exist" / ".minecraft" / "backups" / "aether.zip"
+        )
+        with pytest.raises(FileExistsError):
+            place.link_instance(
+                Path("backups") / "aether.zip",
+                tmp_path / "i_exist",
+                aether_dot_zip,
+                check_exists=check_exists,
+            )
+
+        assert (
+            tmp_path / "i_exist" / ".minecraft" / "backups" / "aether.zip"
+        ).read_bytes() == beether_contents
+
+        assert not (
+            tmp_path / "i_exist" / ".minecraft" / "backups" / "aether.zip"
+        ).is_symlink()

--- a/enderchest/test/test_sync.py
+++ b/enderchest/test/test_sync.py
@@ -1,5 +1,6 @@
 """Test functionality around rsync script generation"""
 import os
+import subprocess
 
 import pytest
 
@@ -57,3 +58,78 @@ class TestLinkToOtherChests:
         sync.link_to_other_chests(local_enderchest / "..", *remotes)
 
         assert os.access(local_enderchest / "local-only" / script, os.X_OK)
+
+    @pytest.mark.parametrize("script", ("open.sh", "close.sh"))
+    def test_link_by_default_does_not_overwrite_scripts(self, script, local_enderchest):
+        (local_enderchest / "local-only" / script).write_text("echo hello\n")
+
+        with pytest.warns() as warning_log:
+            sync.link_to_other_chests(local_enderchest / "..", *remotes)
+
+        assert len(warning_log) == 1
+        assert "skipping" in warning_log[0].message.args[0].lower()
+
+        assert (local_enderchest / "local-only" / script).read_text() == "echo hello\n"
+
+    def test_link_can_be_made_to_overwrite_scripts(self, local_enderchest):
+        for script in ("open.sh", "close.sh"):
+            (local_enderchest / "local-only" / script).write_text("echo hello\n")
+
+        with pytest.warns() as warning_log:
+            sync.link_to_other_chests(local_enderchest / "..", *remotes, overwrite=True)
+
+        assert len(warning_log) == 2
+        assert all(
+            (
+                "overwriting" in warning_message.message.args[0].lower()
+                for warning_message in warning_log
+            )
+        )
+
+        assert not any(
+            (
+                (local_enderchest / "local-only" / script).read_text() == "echo hello\n"
+                for script in ("open.sh", "close.sh")
+            )
+        )
+
+    @pytest.mark.parametrize("script", ("open.sh", "close.sh"))
+    def test_scripts_just_scare_and_quit_by_default(self, script, local_enderchest):
+        sync.link_to_other_chests(
+            local_enderchest / ".."
+        )  # no remotes means shouldn't do anything even if test fails
+
+        script_path = local_enderchest / "local-only" / script
+        with script_path.open("a") as script_file:
+            script_file.write('echo "I should not be reachable"\n')
+
+        result = subprocess.run(
+            [script_path, "--dry-run"],  # out of an overabundance of caution
+            capture_output=True,
+        )
+
+        assert result.returncode == 1
+        assert "DELETE AFTER READING" in result.stdout.decode()
+        if script == "open.sh":
+            assert "Could not pull changes" not in result.stdout.decode()
+        assert "I should not be reachable" not in result.stdout.decode()
+
+    @pytest.mark.parametrize("script", ("open.sh", "close.sh"))
+    def test_yes_you_can_disable_the_scare_warning(self, script, local_enderchest):
+        sync.link_to_other_chests(local_enderchest / "..", omit_scare_message=True)
+
+        script_path = local_enderchest / "local-only" / script
+        with script_path.open("a") as script_file:
+            script_file.write('echo "You made it"\n')
+
+        result = subprocess.run(
+            [script_path, "--dry-run"],  # out of an overabundance of caution
+            capture_output=True,
+        )
+
+        if script == "open.sh":
+            assert result.returncode == 1
+            assert "Could not pull changes" in result.stdout.decode()
+        else:
+            assert result.returncode == 0
+            assert "You made it" in result.stdout.decode()

--- a/enderchest/test/test_sync.py
+++ b/enderchest/test/test_sync.py
@@ -98,6 +98,7 @@ class TestScriptGeneration:
         )
 
     @pytest.mark.parametrize("script", ("open.sh", "close.sh"))
+    @pytest.mark.xfail(sys.platform.startswith("win"), reason="only done bash so far")
     def test_scripts_just_scare_and_quit_by_default(self, script, local_enderchest):
         sync.link_to_other_chests(
             local_enderchest / ".."
@@ -119,6 +120,7 @@ class TestScriptGeneration:
         assert "I should not be reachable" not in result.stdout.decode()
 
     @pytest.mark.parametrize("script", ("open.sh", "close.sh"))
+    @pytest.mark.xfail(sys.platform.startswith("win"), reason="only done bash so far")
     def test_yes_you_can_disable_the_scare_warning(self, script, local_enderchest):
         sync.link_to_other_chests(local_enderchest / "..", omit_scare_message=True)
 

--- a/enderchest/test/test_sync.py
+++ b/enderchest/test/test_sync.py
@@ -1,13 +1,13 @@
 """Test functionality around rsync script generation"""
 import os
 import shutil
-import subprocess
 import sys
 from pathlib import Path
 
 import pytest
 
 from enderchest import sync
+from enderchest.cli import _run_bash
 from enderchest.craft import craft_ender_chest
 from enderchest.place import place_enderchest
 from enderchest.sync import Remote, RemoteSync
@@ -207,8 +207,10 @@ class TestScriptGeneration:
         with script_path.open("a") as script_file:
             script_file.write('echo "I should not be reachable"\n')
 
-        result = subprocess.run(
-            [script_path, "--dry-run"],  # out of an overabundance of caution
+        result = _run_bash(
+            local_enderchest,
+            script_path,
+            "--dry-run",  # out of an overabundance of caution)
             capture_output=True,
         )
 
@@ -227,8 +229,10 @@ class TestScriptGeneration:
         with script_path.open("a") as script_file:
             script_file.write('echo "You made it"\n')
 
-        result = subprocess.run(
-            [script_path, "--dry-run"],  # out of an overabundance of caution
+        result = _run_bash(
+            local_enderchest,
+            script_path,
+            "--dry-run",  # out of an overabundance of caution
             capture_output=True,
         )
 
@@ -304,8 +308,10 @@ class TestSyncing:
             local_enderchest / "..", remote, omit_scare_message=True
         )
 
-        result = subprocess.run(
-            [local_enderchest / "local-only" / "open.sh", "--verbose"],
+        result = _run_bash(
+            local_enderchest,
+            local_enderchest / "local-only" / "open.sh",
+            "--verbose",
             capture_output=True,
         )
 
@@ -336,8 +342,10 @@ class TestSyncing:
             local_enderchest / "..", remote, omit_scare_message=True
         )
 
-        result = subprocess.run(
-            [local_enderchest / "local-only" / "open.sh", "--verbose"],
+        result = _run_bash(
+            local_enderchest,
+            local_enderchest / "local-only" / "open.sh",
+            "--verbose",
             capture_output=True,
         )
 
@@ -380,8 +388,10 @@ class TestSyncing:
             local_enderchest / "..", remote, omit_scare_message=True
         )
 
-        result = subprocess.run(
-            [local_enderchest / "local-only" / "close.sh", "--verbose"],
+        result = _run_bash(
+            local_enderchest,
+            local_enderchest / "local-only" / "close.sh",
+            "--verbose",
             capture_output=True,
         )
 
@@ -412,8 +422,10 @@ class TestSyncing:
             local_enderchest / "..", remote, omit_scare_message=True
         )
 
-        result = subprocess.run(
-            [local_enderchest / "local-only" / "close.sh", "--verbose"],
+        result = _run_bash(
+            local_enderchest,
+            local_enderchest / "local-only" / "close.sh",
+            "--verbose",
             capture_output=True,
         )
 
@@ -430,8 +442,10 @@ class TestSyncing:
             local_enderchest / "..", remote, local_alias="this", omit_scare_message=True
         )
 
-        result = subprocess.run(
-            [local_enderchest / "local-only" / "close.sh", "--verbose"],
+        result = _run_bash(
+            local_enderchest,
+            local_enderchest / "local-only" / "close.sh",
+            "--verbose",
             capture_output=True,
         )
 
@@ -473,8 +487,10 @@ class TestSyncing:
             post_close=["# all done", "echo close end"],
         )
 
-        result = subprocess.run(
-            [local_enderchest / "local-only" / f"{operation}.sh", "--verbose"],
+        result = _run_bash(
+            local_enderchest,
+            local_enderchest / "local-only" / f"{operation}.sh",
+            "--verbose",
             capture_output=True,
         )
 

--- a/enderchest/test/test_sync.py
+++ b/enderchest/test/test_sync.py
@@ -129,22 +129,23 @@ rsync -az --delete \
             "source",
             Remote("faraway", 'maybe here?/definitely+not+"here"/$$$'),
         )
+        cwd = Path(os.getcwd()).as_posix()
         assert (yeet.strip(), yoink.strip()) == (
             rf'''# sync changes from this EnderChest to faraway
 rsync -az --delete \
-    '{os.getcwd()}/C Drive/Games (and other stuff)/minecr@ft'/EnderChest/ \
+    '{cwd}/C Drive/Games (and other stuff)/minecr@ft'/EnderChest/ \
     faraway:'maybe here?/definitely+not+"here"/$$$'/EnderChest/ \
     --exclude=".git" --exclude="local-only" --exclude="other-locals" \
     "$@"
 # backup local settings to faraway
 rsync -az --delete \
-    '{os.getcwd()}/C Drive/Games (and other stuff)/minecr@ft'/EnderChest/local-only/ \
+    '{cwd}/C Drive/Games (and other stuff)/minecr@ft'/EnderChest/local-only/ \
     faraway:'maybe here?/definitely+not+"here"/$$$'/EnderChest/other-locals/source \
     "$@"''',
             rf'''# sync changes from faraway to this EnderChest
 rsync -az --delete \
     faraway:'maybe here?/definitely+not+"here"/$$$'/EnderChest/ \
-    '{os.getcwd()}/C Drive/Games (and other stuff)/minecr@ft'/EnderChest/ \
+    '{cwd}/C Drive/Games (and other stuff)/minecr@ft'/EnderChest/ \
     --exclude=".git" --exclude="local-only" --exclude="other-locals" \
     "$@"''',
         )

--- a/enderchest/test/test_sync.py
+++ b/enderchest/test/test_sync.py
@@ -257,7 +257,7 @@ class TestSyncing:
             / "client-only"
             / "config"
             / "pupil.properties@axolotl@bee@cow"
-        ).write_text("relaxed\n")
+        ).write_text("constricted\n")
 
         assert (
             remote.root
@@ -284,4 +284,4 @@ class TestSyncing:
             / "client-only"
             / "config"
             / "pupil.properties@axolotl@bee@cow"
-        ).read_text() == "relaxed\n"
+        ).read_text() == "constricted\n"

--- a/enderchest/test/test_sync.py
+++ b/enderchest/test/test_sync.py
@@ -1,6 +1,7 @@
 """Test functionality around rsync script generation"""
 import os
 import shutil
+import sys
 from pathlib import Path
 
 import pytest
@@ -242,6 +243,9 @@ class TestScriptGeneration:
             assert "You made it" in result.stdout.decode()
 
 
+@pytest.mark.xfail(
+    sys.platform.startswith("win"), reason="shlex is only guaranteed for posix"
+)
 class TestSyncing:
     """This is only going to cover syncing locally"""
 
@@ -304,7 +308,6 @@ class TestSyncing:
         sync.link_to_other_chests(
             local_enderchest / "..", remote, omit_scare_message=True
         )
-        print((local_enderchest / "local-only" / "open.sh").read_text())
 
         result = _run_bash(
             local_enderchest,

--- a/enderchest/test/test_sync.py
+++ b/enderchest/test/test_sync.py
@@ -1,7 +1,6 @@
 """Test functionality around rsync script generation"""
 import os
 import shutil
-import sys
 from pathlib import Path
 
 import pytest
@@ -197,7 +196,6 @@ class TestScriptGeneration:
         )
 
     @pytest.mark.parametrize("script", ("open.sh", "close.sh"))
-    @pytest.mark.xfail(sys.platform.startswith("win"), reason="only done bash so far")
     def test_scripts_just_scare_and_quit_by_default(self, script, local_enderchest):
         sync.link_to_other_chests(
             local_enderchest / ".."
@@ -221,7 +219,6 @@ class TestScriptGeneration:
         assert "I should not be reachable" not in result.stdout.decode()
 
     @pytest.mark.parametrize("script", ("open.sh", "close.sh"))
-    @pytest.mark.xfail(sys.platform.startswith("win"), reason="only done bash so far")
     def test_yes_you_can_disable_the_scare_warning(self, script, local_enderchest):
         sync.link_to_other_chests(local_enderchest / "..", omit_scare_message=True)
 

--- a/enderchest/test/test_sync.py
+++ b/enderchest/test/test_sync.py
@@ -304,6 +304,7 @@ class TestSyncing:
         sync.link_to_other_chests(
             local_enderchest / "..", remote, omit_scare_message=True
         )
+        print((local_enderchest / "local-only" / "open.sh").read_text())
 
         result = _run_bash(
             local_enderchest,

--- a/enderchest/test/test_sync.py
+++ b/enderchest/test/test_sync.py
@@ -244,7 +244,6 @@ class TestScriptGeneration:
             assert "You made it" in result.stdout.decode()
 
 
-@pytest.mark.xfail(sys.platform.startswith("win"), reason="only done bash so far")
 class TestSyncing:
     """This is only going to cover syncing locally"""
 

--- a/enderchest/test/test_sync.py
+++ b/enderchest/test/test_sync.py
@@ -324,3 +324,30 @@ class TestSyncing:
             assert (
                 list(object_to_be_removed.parent.glob(object_to_be_removed.name)) == []
             )
+
+    def test_close_backs_up_this_local(self, local_enderchest, remote):
+
+        sync.link_to_other_chests(
+            local_enderchest / "..", remote, local_alias="this", omit_scare_message=True
+        )
+
+        result = subprocess.run(
+            [local_enderchest / "local-only" / "close.sh", "--verbose"],
+            capture_output=True,
+        )
+
+        assert result.returncode == 0
+
+        assert sorted(
+            [
+                file.relative_to(local_enderchest / "local-only")
+                for file in (local_enderchest / "local-only").rglob("*")
+            ]
+        ) == sorted(
+            [
+                file.relative_to(remote.root / "EnderChest" / "other-locals" / "this")
+                for file in (
+                    remote.root / "EnderChest" / "other-locals" / "this"
+                ).rglob("*")
+            ]
+        )

--- a/enderchest/test/test_sync.py
+++ b/enderchest/test/test_sync.py
@@ -1,7 +1,7 @@
 """Test functionality around rsync script generation"""
 import os
-import posixpath
 import shutil
+from pathlib import Path
 
 import pytest
 
@@ -81,19 +81,19 @@ class TestCommandBuilding:
         assert (yeet.strip(), yoink.strip()) == (
             rf'''# sync changes from this EnderChest to that
 rsync -az --delete \
-    {posixpath.expanduser("~")}/minecraft/EnderChest/ \
+    {Path.home().as_posix()}/minecraft/EnderChest/ \
     me@there:/home/me/minecraft/EnderChest/ \
     --exclude=".git" --exclude="local-only" --exclude="other-locals" \
     "$@"
 # backup local settings to that
 rsync -az --delete \
-    {posixpath.expanduser("~")}/minecraft/EnderChest/local-only/ \
+    {Path.home().as_posix()}/minecraft/EnderChest/local-only/ \
     me@there:/home/me/minecraft/EnderChest/other-locals/this \
     "$@"''',
             rf'''# sync changes from that to this EnderChest
 rsync -az --delete \
     me@there:/home/me/minecraft/EnderChest/ \
-    {posixpath.expanduser("~")}/minecraft/EnderChest/ \
+    {Path.home().as_posix()}/minecraft/EnderChest/ \
     --exclude=".git" --exclude="local-only" --exclude="other-locals" \
     "$@"''',
         )
@@ -106,19 +106,19 @@ rsync -az --delete \
         assert (yeet.strip(), yoink.strip()) == (
             rf'''# sync changes from this EnderChest to next door
 rsync -az --delete \
-    {posixpath.expanduser("~")}/minecraft/EnderChest/ \
+    {Path.home().as_posix()}/minecraft/EnderChest/ \
     ~/minecraft2/EnderChest/ \
     --exclude=".git" --exclude="local-only" --exclude="other-locals" \
     "$@"
 # backup local settings to next door
 rsync -az --delete \
-    {posixpath.expanduser("~")}/minecraft/EnderChest/local-only/ \
+    {Path.home().as_posix()}/minecraft/EnderChest/local-only/ \
     ~/minecraft2/EnderChest/other-locals/local \
     "$@"''',
             rf'''# sync changes from next door to this EnderChest
 rsync -az --delete \
     ~/minecraft2/EnderChest/ \
-    {posixpath.expanduser("~")}/minecraft/EnderChest/ \
+    {Path.home().as_posix()}/minecraft/EnderChest/ \
     --exclude=".git" --exclude="local-only" --exclude="other-locals" \
     "$@"''',
         )

--- a/enderchest/test/test_sync.py
+++ b/enderchest/test/test_sync.py
@@ -1,0 +1,59 @@
+"""Test functionality around rsync script generation"""
+import os
+
+import pytest
+
+from enderchest import sync
+from enderchest.sync import Remote
+
+remotes = (
+    Remote("localhost", "~/minecraft", "openbagtwo", "Not Actually Remote"),
+    Remote("8.8.8.8", "/root/minecraft", "sergey", "Not-Bing"),
+    Remote("spare-pi", "/opt/minecraft", "pi"),
+    Remote("steamdeck.local", "~/minecraft"),
+)
+
+
+class TestRemote:
+    @pytest.mark.parametrize("remote", remotes)
+    def test_remote_is_trivially_serializable(self, remote):
+        remote_as_str = str(remote)
+        remote_from_str = eval(remote_as_str)  # not that you should ever use eval
+
+        assert remote == remote_from_str
+
+    @pytest.mark.parametrize(
+        "remote, expected",
+        zip(
+            remotes, ("Not Actually Remote", "Not-Bing", "spare-pi", "steamdeck.local")
+        ),
+    )
+    def test_alias_fallback(self, remote, expected):
+        assert remote.alias == expected
+
+    @pytest.mark.parametrize(
+        "remote, expected",
+        zip(
+            remotes,
+            (
+                "openbagtwo@localhost:~/minecraft",
+                "sergey@8.8.8.8:/root/minecraft",
+                "pi@spare-pi:/opt/minecraft",
+                "steamdeck.local:~/minecraft",
+            ),
+        ),
+    )
+    def test_remote_folder(self, remote, expected):
+        assert remote.remote_folder == expected
+
+
+class TestLinkToOtherChests:
+    @pytest.mark.parametrize("script", ("open.sh", "close.sh"))
+    def test_link_to_other_chests_generates_executable_scripts(
+        self, script, local_enderchest
+    ):
+        assert list((local_enderchest / "local-only").glob("*.sh")) == []
+
+        sync.link_to_other_chests(local_enderchest / "..", *remotes)
+
+        assert os.access(local_enderchest / "local-only" / script, os.X_OK)

--- a/enderchest/test/test_sync.py
+++ b/enderchest/test/test_sync.py
@@ -1,7 +1,7 @@
 """Test functionality around rsync script generation"""
 import os
+import posixpath
 import shutil
-from pathlib import Path
 
 import pytest
 
@@ -81,19 +81,19 @@ class TestCommandBuilding:
         assert (yeet.strip(), yoink.strip()) == (
             rf'''# sync changes from this EnderChest to that
 rsync -az --delete \
-    {Path.home()}/minecraft/EnderChest/ \
+    {posixpath.expanduser("~")}/minecraft/EnderChest/ \
     me@there:/home/me/minecraft/EnderChest/ \
     --exclude=".git" --exclude="local-only" --exclude="other-locals" \
     "$@"
 # backup local settings to that
 rsync -az --delete \
-    {Path.home()}/minecraft/EnderChest/local-only/ \
+    {posixpath.expanduser("~")}/minecraft/EnderChest/local-only/ \
     me@there:/home/me/minecraft/EnderChest/other-locals/this \
     "$@"''',
             rf'''# sync changes from that to this EnderChest
 rsync -az --delete \
     me@there:/home/me/minecraft/EnderChest/ \
-    {Path.home()}/minecraft/EnderChest/ \
+    {posixpath.expanduser("~")}/minecraft/EnderChest/ \
     --exclude=".git" --exclude="local-only" --exclude="other-locals" \
     "$@"''',
         )
@@ -106,19 +106,19 @@ rsync -az --delete \
         assert (yeet.strip(), yoink.strip()) == (
             rf'''# sync changes from this EnderChest to next door
 rsync -az --delete \
-    {Path.home()}/minecraft/EnderChest/ \
+    {posixpath.expanduser("~")}/minecraft/EnderChest/ \
     ~/minecraft2/EnderChest/ \
     --exclude=".git" --exclude="local-only" --exclude="other-locals" \
     "$@"
 # backup local settings to next door
 rsync -az --delete \
-    {Path.home()}/minecraft/EnderChest/local-only/ \
+    {posixpath.expanduser("~")}/minecraft/EnderChest/local-only/ \
     ~/minecraft2/EnderChest/other-locals/local \
     "$@"''',
             rf'''# sync changes from next door to this EnderChest
 rsync -az --delete \
     ~/minecraft2/EnderChest/ \
-    {Path.home()}/minecraft/EnderChest/ \
+    {posixpath.expanduser("~")}/minecraft/EnderChest/ \
     --exclude=".git" --exclude="local-only" --exclude="other-locals" \
     "$@"''',
         )

--- a/enderchest/test/test_sync.py
+++ b/enderchest/test/test_sync.py
@@ -388,6 +388,10 @@ class TestSyncing:
             remote_sync,
             local_alias="this",
             omit_scare_message=True,
+            pre_open=["echo open start"],
+            pre_close=["echo close start"],
+            post_open=["echo open end"],
+            post_close=["# all done", "echo close end"],
         )
 
         result = subprocess.run(
@@ -399,7 +403,9 @@ class TestSyncing:
 
         output = result.stdout.decode().splitlines()
 
-        assert int(output[0]), int(output[-1]) == (
-            1 + operation == "close",
-            3 + operation == "close",
+        assert (output[0], int(output[1]), int(output[-2]), output[-1]) == (
+            f"{operation} start",
+            1 + (operation == "close"),
+            3 + (operation == "close"),
+            f"{operation} end",
         )

--- a/enderchest/test/test_sync.py
+++ b/enderchest/test/test_sync.py
@@ -2,6 +2,7 @@
 import os
 import shutil
 import subprocess
+import sys
 
 import pytest
 
@@ -138,6 +139,7 @@ class TestScriptGeneration:
             assert "You made it" in result.stdout.decode()
 
 
+@pytest.mark.xfail(sys.platform.startswith("win"), reason="only done bash so far")
 class TestSyncing:
     """This is only going to cover syncing locally"""
 

--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ dependencies:
   - python=3.10
   - ipython>=8
   - jupyterlab>=3
+  - rsync
   - black
   - isort
   - mypy

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,7 @@ parentdir_prefix = enderchest-
 
 [mypy]
 ignore_missing_imports = True
+show_error_codes = True
 
 [isort]
 line_length = 88

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,3 +21,6 @@ profile = black
 [flake8]
 max-line-length = 88
 extend-ignore = E203
+
+[coverage:run]
+omit=enderchest/test/*, enderchest/_version.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,3 +17,7 @@ ignore_missing_imports = True
 [isort]
 line_length = 88
 profile = black
+
+[flake8]
+max-line-length = 88
+extend-ignore = E203

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     description="syncing and linking for all your Minecraft instances",
     author='Gili "OpenBagTwo" Barlev',
     url="https://github.com/OpenBagTwo/EnderChest",
-    packages=["enderchest"],
+    packages=["enderchest", "enderchest/test"],
     entry_points={
         "console_scripts": [
             "enderchest = enderchest.cli:main",


### PR DESCRIPTION
This release adds two new actions:
- `enderchest open` will pull changes from a remote EnderChest installation
- `enderchest close` will push local changes to any remote EnderChest installations

To enable this, running `enderchest craft` will generate two bash* scripts in the `local-only` folder--`open.sh` and `close.sh`--which perform the syncing via rsync*. The intention is for these scripts to serve as _starting points_ that a user can edit and customize by, say, syncing non-EnderChest folders or adding version control. The flip side of that is that the scripts generated by `enderchest craft` **are not runnable by default**--the user **must** go into each file and edit out a scare warning and exit statement (while hopefully checking the scripts for errors) before the commands will run.

To help facilitate the syncing between many EnderChest instances, this release also adds on a configuration file format, an example of which can be found [here](https://github.com/OpenBagTwo/EnderChest/blob/dev/enderchest/test/example_configs/example.cfg). You don't need to use a config, and the config is neither needed nor referenced outside of running `craft`, but the functionality is there for convenience.

### Unit Tests
This release adds a comprehensive suite of unit tests (written using [`py.test`](https://docs.pytest.org/)) to the package. These cover not just internal logic but go all the way up to testing symlink resolution and actual file syncing. While they of course cannot cover every possible contingency, they should at least provide a degree of confidence that the `enderchest` package will work as intended on the platform on which it is installed.

### CI/CD
Thanks to GitHub actions, this repo now has a CI/CD pipeline that, for now, just runs cross-platform tests for any PR. Eventually this will be expanded to automatically producing and publishing builds to PyPI, conda and maybe even stand-alone executables in flathub or brew.

### *Windows Support?
The syncing functionality is built around bash and rsync, which come pre-installed on most posix (read: mac and liinux) machines. What I don't know is how well this package will work on Windows, primarily because the last time I had a Windows machine it ran XP. I know [Cygwin](https://www.cygwin.com/) is a thing, as is WSL. So the hope is that it should be possible to run `enderchest` on Windows, and GitHub actions should provide *some* measure of answer regarding what does (or does not) work. For now, consider Windows **not officially supported** but this may change.

***Update:** linking appears to work fine on Windows, and syncing should work as well **in principle**. The issue appears to be that [`shlex.quote`](https://docs.python.org/3/library/shlex.html#shlex.quote) is not properly escaping Windows absolute paths (so rsync thinks that, for example, `C:/dos` is on some server named "C"). This should be something a user can correct manually when they go to remove the scare warning. Given that, I'm punting on  full out-of-the-box Windows sync compatibility for this release.*