### PR TITLE
Support linking resources with servers

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -46,5 +46,5 @@ jobs:
         pip install pytest mypy black isort flake8 pytest-cov
     - name: Run unit tests
       run: |
-        pytest -vv --cov=enderchest
+        pytest -vv --doctest-modules --cov=enderchest
       

--- a/enderchest/place.py
+++ b/enderchest/place.py
@@ -5,6 +5,31 @@ from pathlib import Path
 from . import contexts
 
 
+def _tokenize_server_name(tag: str) -> str:
+    """For easier integration into systemd, and because spaces in paths are a hassle
+    in general, assume (enforce?) that server folders will have "tokenized" names and
+    thus map any tags (where spaces are fine) to the correct server folder.
+
+    Parameters
+    ----------
+    tag : str
+        The unprocessed tag value, which can have spaces and capital letters
+
+    Returns
+    -------
+    str
+        The expected "tokenized" server folder name, which:
+          - will be all lowercase
+          - has all spaces replaced with periods
+
+    Examples
+    --------
+    >>> _tokenize_server_name("Chaos Awakening")
+    'chaos.awakening'
+    """
+    return tag.lower().replace(" ", ".")
+
+
 def place_enderchest(root: str | os.PathLike, cleanup: bool = True) -> None:
     """Link all instance files and folders
 
@@ -14,15 +39,13 @@ def place_enderchest(root: str | os.PathLike, cleanup: bool = True) -> None:
         The root directory that contains the EnderChest directory, instances and servers
     cleanup : bool, optional
         By default, this method will remove any broken links in your instances and
-        servers folders.
-        To disable this behavior, pass in cleanup=False
+        servers folders. To disable this behavior, pass in cleanup=False
     """
     instances = Path(root) / "instances"
     servers = Path(root) / "servers"
     for context_type, context_root in contexts(root)._asdict().items():
-        # make_server_links = context_type in ("universal", "server_only")
+        make_server_links = context_type in ("universal", "server_only")
         make_instance_links = context_type in ("universal", "client_only", "local_only")
-
         assets = sorted(context_root.rglob("*@*"))
         for asset in assets:
             if not asset.exists():
@@ -31,8 +54,8 @@ def place_enderchest(root: str | os.PathLike, cleanup: bool = True) -> None:
             for tag in tags:
                 if make_instance_links:
                     link_instance(path, instances / tag, asset)
-                # if make_server_links:
-                #     link_server(path, instances / tag, asset)
+                if make_server_links:
+                    link_server(path, servers / _tokenize_server_name(tag), asset)
     if cleanup:
         for file in (*instances.rglob("*"), *servers.rglob("*")):
             if not file.exists():
@@ -82,7 +105,9 @@ def link_instance(
     os.symlink(relative_path, instance_file)
 
 
-def link_server(resource_path: str, server_folder: Path, destination: Path) -> None:
+def link_server(
+    resource_path: str, server_folder: Path, destination: Path, check_exists=True
+) -> None:
     """Create a symlink for the specified resource from an server's space pointing to
     the tagged file / folder living in the EnderChest folder.
 
@@ -95,6 +120,9 @@ def link_server(resource_path: str, server_folder: Path, destination: Path) -> N
     destination : Path
         the location to link, where the file or older actually lives (inside the
         EnderChest folder)
+    check_exists : bool, optional
+        By default, this method will only create links if the server_folder exists.
+        To create links regardless, pass check_exists=False
 
     Returns
     -------
@@ -102,6 +130,16 @@ def link_server(resource_path: str, server_folder: Path, destination: Path) -> N
 
     Notes
     -----
-    This method will create any folders that do not existc
+    - This method will create any folders that do not exist within a server folder
+    - This method will overwrite existing symlinks but will not overwrite any actual
+      files
     """
-    raise NotImplementedError
+    if not server_folder.exists() and check_exists:
+        return
+    server_file = server_folder / resource_path
+    server_file.parent.mkdir(parents=True, exist_ok=True)
+    relative_path = os.path.relpath(destination, server_file.parent)
+    if server_file.is_symlink():
+        # remove previous symlink in this spot
+        server_file.unlink()
+    os.symlink(relative_path, server_file)

--- a/enderchest/test/conftest.py
+++ b/enderchest/test/conftest.py
@@ -78,7 +78,7 @@ def local_enderchest(local_root):
             chest_folder
             / "local-only"
             / "shaderpacks"
-            / "Seuss CitH.zip.txt@axolotl@bee@cow"
+            / "Seuss CitH.zip.txt@axolotl@bee@Chest Boat"
         ): (
             "with settings at max"
             "\nits important to note"
@@ -92,7 +92,7 @@ def local_enderchest(local_root):
     ).symlink_to(local_root / "workspace" / "neat_resource_pack")
 
     symlinks: dict[Path, Path] = {  # map of links to targets
-        (chest_folder / "client-only" / "saves" / "olam@axolotl@bee@cow"): (
+        (chest_folder / "client-only" / "saves" / "olam@axolotl@bee@Chest Boat"): (
             local_root / "worlds" / "olam"
         ),
         (chest_folder / "global" / "mods" / "BME.jar@axolotl"): (
@@ -111,7 +111,7 @@ def local_enderchest(local_root):
             / "libs"
             / "BME_1.19.1_beta.jar"
         ),
-        (chest_folder / "global" / "mods" / "BME.jar@cow"): (
+        (chest_folder / "global" / "mods" / "BME.jar@Chest Boat"): (
             local_root
             / "workspace"
             / "BestModEver"

--- a/enderchest/test/test_sync.py
+++ b/enderchest/test/test_sync.py
@@ -268,12 +268,17 @@ class TestSyncing:
         )
 
         shutil.copy(
-            (local_enderchest / "client-only" / "saves" / "olam@axolotl@bee@cow"),
-            (ender_chest / "client-only" / "saves" / "olam@axolotl@bee@cow"),
+            (
+                local_enderchest
+                / "client-only"
+                / "saves"
+                / "olam@axolotl@bee@Chest Boat"
+            ),
+            (ender_chest / "client-only" / "saves" / "olam@axolotl@bee@Chest Boat"),
             follow_symlinks=False,
         )
 
-        for instance in ("axolotl", "bee", "cow"):
+        for instance in ("axolotl", "bee", "Chest Boat"):
             shutil.copy(
                 (local_enderchest / "global" / "mods" / f"BME.jar@{instance}"),
                 (ender_chest / "global" / "mods" / f"BME.jar@{instance}"),
@@ -289,13 +294,16 @@ class TestSyncing:
             ender_chest
             / "local-only"
             / "shaderpacks"
-            / "SildursMonochromeShaders.zip@axolotl@bee@cow@dolphin"
+            / "SildursMonochromeShaders.zip@axolotl@bee@Chest Boat@dolphin"
         ).touch()
         (ender_chest / "local-only" / "BME_indev.jar@axolotl").write_bytes(
             b"alltheboops"
         )
         (
-            ender_chest / "client-only" / "config" / "pupil.properties@axolotl@bee@cow"
+            ender_chest
+            / "client-only"
+            / "config"
+            / "pupil.properties@axolotl@bee@Chest Boat"
         ).write_text("dilated\n")
 
         yield Remote(None, ender_chest / "..", None, "behind_the_door")
@@ -376,7 +384,7 @@ class TestSyncing:
             local_enderchest
             / "client-only"
             / "config"
-            / "pupil.properties@axolotl@bee@cow"
+            / "pupil.properties@axolotl@bee@Chest Boat"
         ).write_text("constricted\n")
 
         remote_config = (
@@ -384,7 +392,7 @@ class TestSyncing:
             / "EnderChest"
             / "client-only"
             / "config"
-            / "pupil.properties@axolotl@bee@cow"
+            / "pupil.properties@axolotl@bee@Chest Boat"
         )
         assert remote_config.read_text() == "dilated\n"
 
@@ -411,7 +419,7 @@ class TestSyncing:
             / "EnderChest"
             / "client-only"
             / "config"
-            / "pupil.properties@axolotl@bee@cow"
+            / "pupil.properties@axolotl@bee@Chest Boat"
         )
         link_to_be_removed = (
             remote.root / "EnderChest" / "global" / "mods" / "AnOkayMod.jar@bee"


### PR DESCRIPTION
`enderchest place` will now create symbolic links inside of folders inside of `$MINECRAFT_ROOT/servers`, which will differ from instance folders by not having everything within a `.minecraft` folder.

The use-case for this is:
1. easy, centralized management of required mods and resourcepacks between clients and servers
2. being able to switch between playing a world in single-player and on a server

When actually using `enderchest place` in this way, a user will probably want to check if a server is running, shut it down before running `enderchest place`, then restart it afterwards, so that will need to go in the docs.