### PR TITLE
Fix inverted --keep-broken behavior

### DIFF
--- a/enderchest/cli.py
+++ b/enderchest/cli.py
@@ -234,7 +234,7 @@ def parse_args(argv: Sequence[str]) -> tuple[_Action, str, dict[str, Any]]:
     action_parsers["place"].add_argument(
         "-k",
         "--keep-broken",
-        action="store_true",
+        action="store_false",
         dest="cleanup",
         help="do not remove broken links when performing place",
     )


### PR DESCRIPTION
Addresses #8, where the default value / set behavior of the optional `--keep-broken` flag for `enderchest place` was inverted (broken links were kept by default, cleaned up when the command was called with `-k`). 

There *had* been a test in place to test this, but the test:
- wasn't actually passing in the flag
- wasn't even mocking the call correctly

### Additional Validation Performed

1. Created a broken link in an instance folder
2. Called `enderchest place -k`
3. Confirmed that the broken link persisted.
4. Called `enderchest place` again
5. Confirmed the deletion of the broken link