### PR TITLE
Better sync outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,5 +132,8 @@ dmypy.json
 .idea
 .vscode
 
+# MacOS gunk
+.DS_Store
+
 # test folders
 testolotl

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ you still have questions, feel free to
 EnderChest is written for **Python 3.10 or greater,** but should otherwise
 run on any architecture or operating system.
 
+Note that the recommended sync protocol is
+[`rsync`](https://www.digitalocean.com/community/tutorials/how-to-use-rsync-to-sync-local-and-remote-directories), and EnderChest requires
+[version 3.2 or newer](https://dev.to/al5ina5/updating-rsync-on-macos-so-you-re-not-stuck-with-14-year-old-software-1b5i).
+However, other protocols are available if a modern `rsync` is not an option for you.
+
 The latest release can be installed from PyPI via `pip`:
 
 ```bash

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,9 +5,14 @@
 
 EnderChest has minimal package dependencies and should run on pretty much
 any computer or operating system. It does require **Python 3.10 or greater,**
-portable distributions (read: no need for admin privileges)  of which are
+portable distributions (read: no need for admin privileges) of which are
 available through miniconda and
 [mambaforge](https://github.com/conda-forge/miniforge#mambaforge).
+
+You can check your Python version by opening a terminal and running:
+```bash
+python3 -V
+```
 
 !!! warning
     Because of EnderChest's
@@ -15,9 +20,17 @@ available through miniconda and
     are required to **turn on Developer Mode**.
     [Read more here.](https://blogs.windows.com/windowsdeveloper/2016/12/02/symlinks-windows-10/)
 
-Once you have Python installed,
+## Installing EnderChest
 
-1. Open a terminal and create a new virtual environment via:
+### Inside a conda environment
+
+Skip this sub-section if you're using the system Python.
+
+These instructions assume that you've already downloaded and installed mambaforge
+or another conda distribution and that mamba/conda is already registered
+to your system path.
+
+1. Open a terminal (miniforge prompt on Windows) and create a new virtual environment via:
    ```bash
    mamba create -n enderchest "python>=3.10" "pip>22"
    ```
@@ -29,14 +42,18 @@ Once you have Python installed,
     conda activate enderchest
     ```
 
-1. Install `enderchest` from PyPI using pip:
+Then continue onto the next section.
+
+### Installation via pip
+
+3. Install `enderchest` from PyPI using pip:
     ```bash
-    python -m pip install --user enderchest[test]
+    python3 -m pip install --user enderchest[test]
     ```
 
-1. Ensure that EnderChest is compatible with your system by running:
+4. Ensure that EnderChest is compatible with your system by running:
     ```bash
-    python -m pytest --pyargs enderchest.test
+    python3 -m pytest --pyargs enderchest.test
     ```
     If all tests pass, then you're good to go!
 
@@ -52,6 +69,48 @@ Once you have Python installed,
     /home/openbagtwo/.mambaforge/envs/enderchest/bin/enderchest
     $ cp /home/openbagtwo/.mambaforge/envs/enderchest/bin/enderchest ~/.local/bin/
     ```
+
+## Installing `rsync`
+
+EnderChest's preferred syncing protocol is
+[`rsync`](https://www.digitalocean.com/community/tutorials/how-to-use-rsync-to-sync-local-and-remote-directories), and EnderChest requires **version 3.2 or newer**.
+
+You can check if a sufficiently recent version of `rsync` is installed
+on your system by running the command:
+
+```bash
+rsync -V
+```
+
+If you get a message back stating: `rsync: -V: unknown option`, then your `rsync`
+is too old (you can confirm this by running `rsync --version`).
+
+### Windows
+Use of `rsync` on Windows [is not currently supported](https://github.com/OpenBagTwo/EnderChest/issues/67),
+though it may be possible using [Cygwin](https://github.com/cygwin/cygwin-install-action)
+or [WSL](https://learn.microsoft.com/en-us/windows/wsl/install).
+
+Luckily, [other protocols are available](../suggestions#other-syncing-protocols).
+
+### Conda (macOS and Linux)
+
+If you've already installed EnderChest in a conda-managed virtual environment,
+following the instructions above,
+[conda builds of `rsync` are available](https://anaconda.org/conda-forge/rsync)
+for Mac and Linux and can be installed within your virtual environment via:
+
+```bash
+conda activate enderchest
+mamba install rsync
+```
+(substituting `conda` for `mamba` if needed).
+
+### Other options for macOS
+
+You can (and, honestly, should) upgrade your
+system's rsync installation via
+[homebrew](https://formulae.brew.sh/formula/rsync) or
+[MacPorts](https://ports.macports.org/port/rsync/)
 
 ## Bleeding Edge
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -174,21 +174,21 @@ sync!).
 Once you've finished setting up an EnderChest on a given computer, the next
 thing to consider is setting it up on _another_ one. To do that, you'll need
 to set up some form of file transfer. **EnderChest's preferred transfer protocol
-is [rsync](https://www.redhat.com/sysadmin/sync-rsync)**, an extremely official
-and open source tool for performing backups and generally moving files between
-two locations. Most Linux distributions (including SteamOS) come with rsync
-preinstalled, and Mac users can install rsync easily via
+is [`rsync`](https://www.redhat.com/sysadmin/sync-rsync)**, an extremely efficient
+open source tool for performing backups and generally moving files between
+two locations. Most Linux distributions (including SteamOS) come with a
+sufficiently recent version of `rsync` preinstalled (EnderChest requires **`rsync` 3.2 or newer**),
+and Mac users can upgrade their `rsync` easily via
 [homebrew](https://formulae.brew.sh/formula/rsync),
 [MacPorts](https://ports.macports.org/port/rsync/) or
-[conda](https://anaconda.org/conda-forge/rsync). Windows users should
-install [Cygwin](https://www.cygwin.com/install.html) and install
-[rsync](https://www.cygwin.com/packages/summary/rsync.html) through it
-(though other options like
-[WSL](https://thedatafrog.com/en/articles/backup-rsync-windows-wsl/) are available).
+[conda](https://anaconda.org/conda-forge/rsync).
 
-EnderChest does support additional protocols, including those that do not
-depend on external binaries. Details on those are listed
-[here](../suggestions#other-syncing-protocols).
+Windows users may be able to get EnderChest working with `rsync`
+via [Cygwin](https://www.cygwin.com/packages/summary/rsync.html) or
+[WSL](https://thedatafrog.com/en/articles/backup-rsync-windows-wsl/), but
+[this is not currently supported](https://github.com/OpenBagTwo/EnderChest/issues/67),
+and Windows users may be better off using
+[a different protocol](../suggestions#other-syncing-protocols).
 
 To register a remote with your EnderChest, you just need to run the following command:
 

--- a/enderchest/cli.py
+++ b/enderchest/cli.py
@@ -543,9 +543,7 @@ def parse_args(argv: Sequence[str]) -> tuple[Action, Path, int, dict[str, Any]]:
             if "verbosity" in argspec.args + argspec.kwonlyargs:
                 action_kwargs["verbosity"] = verbosity
 
-            log_level = logging.INFO - 10 * verbosity
-            if log_level == logging.NOTSET:  # that's 0, annoyingly enough
-                log_level -= 1
+            log_level = loggers.verbosity_to_log_level(verbosity)
 
             return (
                 action,

--- a/enderchest/loggers.py
+++ b/enderchest/loggers.py
@@ -7,6 +7,7 @@ PLACE_LOGGER = logging.getLogger("enderchest.place")
 SYNC_LOGGER = logging.getLogger("enderchest.sync")
 
 IMPORTANT = 25  # INFO logs that should still be displayed on "-q"
+logging.addLevelName(IMPORTANT, "INFO")
 
 
 class CLIFormatter(logging.Formatter):

--- a/enderchest/loggers.py
+++ b/enderchest/loggers.py
@@ -12,7 +12,7 @@ class CLIFormatter(logging.Formatter):
 
     h/t https://stackoverflow.com/a/56944256"""
 
-    grey = "\x1b[38;20m"
+    grey = "\x1b[2;20m"
     yellow = "\x1b[33;20m"
     bold_red = "\x1b[31;1m"
     reset = "\x1b[0m"

--- a/enderchest/loggers.py
+++ b/enderchest/loggers.py
@@ -6,6 +6,8 @@ GATHER_LOGGER = logging.getLogger("enderchest.gather")
 PLACE_LOGGER = logging.getLogger("enderchest.place")
 SYNC_LOGGER = logging.getLogger("enderchest.sync")
 
+IMPORTANT = 25  # INFO logs that should still be displayed on "-q"
+
 
 class CLIFormatter(logging.Formatter):
     """Colorful formatter for the CLI
@@ -20,6 +22,7 @@ class CLIFormatter(logging.Formatter):
     FORMATS = {
         logging.DEBUG: grey + "%(message)s" + reset,
         logging.INFO: "%(message)s",
+        IMPORTANT: "%(message)s",
         logging.WARNING: yellow + "%(message)s" + reset,
         logging.ERROR: bold_red + "%(message)s" + reset,
         logging.CRITICAL: bold_red + "%(message)s" + reset,
@@ -27,3 +30,28 @@ class CLIFormatter(logging.Formatter):
 
     def format(self, record: logging.LogRecord) -> str:
         return logging.Formatter(self.FORMATS.get(record.levelno)).format(record)
+
+
+def verbosity_to_log_level(verbosity: int) -> int:
+    """Convert a verbosity level (number of `-v`s minus number of `-q`s) to
+    a logging level
+
+    Parameters
+    ----------
+    verbosity: int
+        A verbosity level usually specified by the number of `-v` flags a user
+        provides minus the number of `-q` flags. As a baseline, a verbosity of
+        0 will set the level to handle all INFO-level messages and above.
+
+    Returns
+    -------
+    int
+        The corresponding log level that should be set
+
+    Notes
+    -----
+    Technically the default logging level is set just high enough to exclude
+    DEBUG by default. This allows us to capture intermediate log levels (read:
+    `IMPORTANT`) at the `verbosity = -1` (`-q`) level.
+    """
+    return logging.DEBUG + 1 - 10 * verbosity

--- a/enderchest/remote.py
+++ b/enderchest/remote.py
@@ -8,7 +8,7 @@ from urllib.parse import ParseResult, urlparse
 from . import filesystem as fs
 from . import gather
 from .enderchest import EnderChest
-from .loggers import SYNC_LOGGER
+from .loggers import IMPORTANT, SYNC_LOGGER
 from .prompt import confirm
 from .sync import path_from_uri, pull, push, remote_file, render_remote
 
@@ -161,11 +161,16 @@ def sync_with_remotes(
         else:
             runs = (True, False)
         for do_dry_run in runs:
+            if dry_run:
+                prefix = "Simulating an attempt"
+            else:
+                prefix = "Attempting"
             try:
                 if pull_or_push == "pull":
-                    SYNC_LOGGER.info(
-                        "Attempting to pull changes from"
-                        f" {render_remote(alias, remote_uri)}"
+                    SYNC_LOGGER.log(
+                        IMPORTANT,
+                        f"{prefix} to pull changes"
+                        f" from {render_remote(alias, remote_uri)}",
                     )
                     remote_chest = remote_uri._replace(
                         path=urlparse(
@@ -191,8 +196,10 @@ def sync_with_remotes(
                         **sync_kwargs,
                     )
                 else:
-                    SYNC_LOGGER.info(
-                        f"Attempting to push changes to {render_remote(alias, remote_uri)}"
+                    SYNC_LOGGER.log(
+                        IMPORTANT,
+                        f"{prefix} to push changes"
+                        f" to {render_remote(alias, remote_uri)}",
                     )
                     local_chest = fs.ender_chest_folder(minecraft_root)
                     push(

--- a/enderchest/remote.py
+++ b/enderchest/remote.py
@@ -213,6 +213,7 @@ def sync_with_remotes(
                 ValueError,
                 NotImplementedError,
                 TimeoutError,
+                RuntimeError,
             ) as sync_fail:
                 SYNC_LOGGER.warning(
                     f"Could not sync changes with {render_remote(alias, remote_uri)}:"

--- a/enderchest/sync/__init__.py
+++ b/enderchest/sync/__init__.py
@@ -97,7 +97,7 @@ def remote_file(uri: ParseResult) -> Generator[Path, None, None]:
         A path to a local (temp) copy of the file
     """
     with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
-        pull(uri, Path(tmpdir))
+        pull(uri, Path(tmpdir), verbosity=-1)
         yield Path(tmpdir) / Path(uri.path).name
 
 

--- a/enderchest/sync/rsync.py
+++ b/enderchest/sync/rsync.py
@@ -190,7 +190,7 @@ def summarize_rsync_report(raw_output: str, depth: int = 2) -> None:
                 summary[path_key] = "update"
             else:
                 entry = summary[path_key]
-                if isinstance(entry, str):
+                if isinstance(entry, str):  # pragma: no cover
                     # this should never happen
                     SYNC_LOGGER.error(
                         f"Error parsing {line}:"
@@ -216,7 +216,7 @@ def summarize_rsync_report(raw_output: str, depth: int = 2) -> None:
             SYNC_LOGGER.info(
                 f"Within {path_key}...\n"
                 + "\n".join(
-                    f"  - {op[:-1].title()}ing {count} files"
+                    f"  - {op[:-1].title()}ing {count} file{'' if count == 1 else 's'}"
                     for op, count in report.items()
                 )
             )

--- a/enderchest/sync/rsync.py
+++ b/enderchest/sync/rsync.py
@@ -194,11 +194,11 @@ def summarize_rsync_report(raw_output: str, depth: int = 2) -> list[str]:
         if line == "":  # skip empty lines
             continue
 
-        info = line[:11]
-        full_path = os.path.normpath(line[12:])
+        info = line.split()[0]
+        full_path = os.path.normpath("".join(line.split()[1:]))
         path_key = os.sep.join(full_path.split(os.sep)[:depth])
 
-        if info == "*deleting  ":
+        if info.startswith("*deleting"):
             if full_path == path_key:
                 summary[path_key] = "delete"
             else:
@@ -206,7 +206,7 @@ def summarize_rsync_report(raw_output: str, depth: int = 2) -> list[str]:
                 if not isinstance(entry, str):
                     entry["delete"] += 1
                 # otherwise the whole thing is being deleted
-        elif info[2:] == "+++++++++":  # this is a creation
+        elif info[2:5] == "+++":  # this is a creation
             if full_path == path_key:
                 summary[path_key] = "create"
             else:

--- a/enderchest/sync/rsync.py
+++ b/enderchest/sync/rsync.py
@@ -195,7 +195,7 @@ def summarize_rsync_report(raw_output: str, depth: int = 2) -> list[str]:
             continue
 
         info = line.split()[0]
-        full_path = os.path.normpath("".join(line.split()[1:]))
+        full_path = os.path.normpath(" ".join(line.split()[1:]))
         path_key = os.sep.join(full_path.split(os.sep)[:depth])
 
         if info.startswith("*deleting"):

--- a/enderchest/sync/utils.py
+++ b/enderchest/sync/utils.py
@@ -1,0 +1,60 @@
+"""Non-implementation-specific syncing utilities"""
+import getpass
+import os
+import socket
+from pathlib import Path
+from urllib.parse import ParseResult, unquote
+from urllib.request import url2pathname
+
+
+def get_default_netloc() -> str:
+    """Compile a netloc from environment variables, etc.
+
+    Returns
+    -------
+    str
+        The default netloc, which is {user}@{hostname}
+    """
+    return f"{getpass.getuser()}@{socket.gethostname()}".lower()
+
+
+def path_from_uri(uri: ParseResult) -> Path:
+    """Extract and unquote the path component of a URI to turn it into a pathlib.Path
+
+    h/t https://stackoverflow.com/a/61922504
+
+    Parameters
+    ----------
+    uri : ParseResult
+        The parsed URI to extract the path from
+
+    Returns
+    -------
+    Path
+        The path part of the URI as a Path
+    """
+    host = "{0}{0}{mnt}{0}".format(os.path.sep, mnt=uri.netloc)
+    return Path(os.path.abspath(os.path.join(host, url2pathname(unquote(uri.path)))))
+
+
+def render_remote(alias: str, uri: ParseResult) -> str:
+    """Render a remote to a descriptive string
+
+    Parameters
+    ----------
+    alias : str
+        The name of the remote
+    uri : ParseResult
+        The parsed URI for the remote
+
+    Returns
+    -------
+    str
+        {uri_string} [({alias})]}
+            (if different from the URI hostname)
+    """
+    uri_string = uri.geturl()
+
+    if uri.hostname != alias:
+        uri_string += f" ({alias})"
+    return uri_string

--- a/enderchest/test/test_cli.py
+++ b/enderchest/test/test_cli.py
@@ -80,13 +80,13 @@ class ActionTestSuite:
     @pytest.mark.parametrize(
         "verbosity_flag, expected_verbosity",
         (
-            ("-v", logging.DEBUG),
-            ("-q", logging.WARNING),
-            ("--verbose", logging.DEBUG),
-            ("--quiet", logging.WARNING),
-            ("-vv", -1),
-            ("-qq", logging.ERROR),
-            ("-vvqvqqvqv", logging.DEBUG),
+            ("-v", logging.DEBUG - 9),
+            ("-q", logging.WARNING - 9),
+            ("--verbose", logging.DEBUG - 9),
+            ("--quiet", logging.WARNING - 9),
+            ("-vv", -9),
+            ("-qq", logging.ERROR - 9),
+            ("-vvqvqqvqv", logging.DEBUG - 9),
         ),
     )
     def test_altering_verbosity(self, verbosity_flag, expected_verbosity):

--- a/enderchest/test/test_sync.py
+++ b/enderchest/test/test_sync.py
@@ -388,7 +388,7 @@ class TestRsyncSync(TestFileSync):
 
         # meta-test--make sure that the creation is actually happening
         assert (
-            ">f+++++++++ " + os.path.sep.join(("EnderChest", "1.19", ".bobby", "chunk"))
+            "+++ " + os.path.sep.join(("EnderChest", "1.19", ".bobby", "chunk"))
             in debug_log
         )
 
@@ -418,7 +418,7 @@ class TestRsyncSync(TestFileSync):
 
         # meta-test--make sure that the creation is actually happening
         assert (
-            ">f+++++++++ "
+            "+++ "
             + os.path.sep.join(("EnderChest", "optifine", "mods", "optifine.jar"))
             in debug_log
         )

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,3 +51,4 @@ markdown_extensions:
 - pymdownx.superfences
 - admonition
 - pymdownx.details
+- sane_lists


### PR DESCRIPTION
## Summary
<!--- One sentence summary of this PR. Can oftentimes just be a matter of linking
      to the issue number --->

Addresses #57 by:
- summarizing rsync reports in a way that's useful and customizable
- not suppressing stdout when doing an actual sync and instead making use of some fancy rsync flags to make the output concise and useful (with progress bars!)

## List of Changes
<!--- List out the changes introduced by this PR, permalinking
      (read: with commit hash) to the commit, file or section of code where
      that change was implemented --->
* Refactors the non-impl-specific sync utilities into `sync.utils` instead of leaving them in `__init__.py`
* Leverages a bunch of fancy flags in `rsync` to customize the output--rather than suppressing it--during syncs
* Leverages _separate_ fancy flags in `rsync` to allow EnderChest to _summarize_ the reports of dry runs
* Allows verbosity to be accessed by CLI "actions" that want it
* Adds a new intermediate log level in between INFO and WARNING so that `-q` doesn't have to mean "completely silent"

## Tech Debt and Other Concerns
<!--- Use this section to call out anything in the code (including stuff you
      discovered outside of your contributions!) that you think may cause
      issues either now or further down the road. These will need to be spun
      off into issues before the PR is closed but shouldn't impede you opening
      the PR and starting the review process --->


## To Do
- [x] I need to make sure that all the options used are available on the rsync that ships with all my target platforms. That's part of the reason I'm opening this PR now (test the MacOS runner)
- [x] Document the outputs at the different log levels
- [x] Verbosity tests!

## Validation Performed
<!--- What did you do to ensure that this change is behaving as intended? This
should start with unit tests, but it's usually a good idea to try running
the code in a real setting. Include screenshots if you'd like, but make sure to
remove any personal information you won't want to share --->
* Been informally dogfooding this a bit as I customize the output messages, but I definitely need to be thorough and provide examples of each of the log levels

## PR Type
<!--- Check all that apply --->
- [ ] This PR introduces a breaking change (will
  [require a bump in the minor version](https://semver.org/))
- [ ] The changes in this PR are high urgency and necessitate a hotfix or patch
  release (will require rebasing off of `release`)
- [ ] This is a release (staging) PR (maintainer use only)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.
      All bullets in this section are required to be checked off before the PR can
      be merged, but they don't need to be checked off before the PR is opened.
      If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] I have read [the contributor's guide](https://openbagtwo.github.io/EnderChest/dev/contrib/)
- [x] I have run `mkdocs serve` locally and ensured that all API docs and
  changes I have made to the static pages are rendering correctly, with all links
  working
- [ ] All tech debt concerns have been resolved, documented as issues, or otherwise
  accepted
- [x] I agree to license my contribution to this project under
  [the GNU Public License v3](https://www.gnu.org/licenses/gpl-3.0.en.html)
  <!--- If you wish to use a different compatible license, please edit the above--->


<!--- Adapted from https://github.com/stevemao/github-issue-templates --->
