### PR TITLE
Show shulker boxes that get linked to by an instance

### DIFF
--- a/enderchest/cli.py
+++ b/enderchest/cli.py
@@ -64,7 +64,7 @@ def _list_instance_boxes(
 ):
     """Wrapper to handle the fact that name is a required argument"""
     assert instance_name  # it's required by the parser, so this should be fine
-    gather.load_instance_matches(minecraft_root, instance_name, **kwargs)
+    gather.get_shulker_boxes_matching_instance(minecraft_root, instance_name, **kwargs)
 
 
 def _list_shulker_box(
@@ -72,7 +72,9 @@ def _list_shulker_box(
 ):
     """Wrapper to handle the fact that name is a required argument"""
     assert shulker_box_name  # it's required by the parser, so this should be fine
-    gather.load_shulker_box_matches(minecraft_root, shulker_box_name, **kwargs)
+    gather.get_instances_matching_shulker_box(
+        minecraft_root, shulker_box_name, **kwargs
+    )
 
 
 def _update_ender_chest(

--- a/enderchest/cli.py
+++ b/enderchest/cli.py
@@ -59,6 +59,14 @@ def _craft_shulker_box(minecraft_root: Path, name: str | None = None, **kwargs):
     craft.craft_shulker_box(minecraft_root, name, **kwargs)
 
 
+def _list_instance_boxes(
+    minecraft_root: Path, instance_name: str | None = None, **kwargs
+):
+    """Wrapper to handle the fact that name is a required argument"""
+    assert instance_name  # it's required by the parser, so this should be fine
+    gather.load_instance_matches(minecraft_root, instance_name, **kwargs)
+
+
 def _list_shulker_box(
     minecraft_root: Path, shulker_box_name: str | None = None, **kwargs
 ):
@@ -139,16 +147,29 @@ ACTIONS: tuple[tuple[tuple[str, ...], str, Action], ...] = (
     ),
     (
         tuple(
-            f"{verb} {alias}" for verb in _list_aliases for alias in _instance_aliases
+            f"{verb} {alias}"
+            for verb in _list_aliases
+            for alias in _instance_aliases
+            if alias.endswith("s")
         ),
         "list the minecraft instances registered with your Enderchest",
         gather.load_ender_chest_instances,
     ),
     (
         tuple(
+            f"{verb} {alias}"
+            for verb in _list_aliases
+            for alias in _instance_aliases
+            if not alias.endswith("s")
+        ),
+        "list the shulker boxes that the specified instance links to",
+        _list_instance_boxes,
+    ),
+    (
+        tuple(
             f"{verb} {alias}" for verb in _list_aliases for alias in _shulker_aliases
         ),
-        "list the instances that match the specified shulker box",
+        "list the minecraft instances that match the specified shulker box",
         _list_shulker_box,
     ),
     (
@@ -437,6 +458,14 @@ def generate_parsers() -> tuple[ArgumentParser, dict[str, ArgumentParser]]:
     # list instances options
 
     # list shulkers options
+
+    # list instance box options
+    list_instance_boxes_parser = action_parsers[
+        f"{_list_aliases[0]} {_instance_aliases[0]}"
+    ]
+    list_instance_boxes_parser.add_argument(
+        "instance_name", help="The name of the minecraft instance to query"
+    )
 
     # list shulker options
     list_shulker_parser = action_parsers[f"{_list_aliases[0]} {_shulker_aliases[0]}"]

--- a/enderchest/gather.py
+++ b/enderchest/gather.py
@@ -292,7 +292,9 @@ def load_ender_chest_remotes(
     return remote_list
 
 
-def load_instance_matches(minecraft_root: Path, instance_name: str) -> list[ShulkerBox]:
+def get_shulker_boxes_matching_instance(
+    minecraft_root: Path, instance_name: str
+) -> list[ShulkerBox]:
     """Get the list of shulker boxes that the specified instance links to
 
     Parameters
@@ -342,7 +344,7 @@ def load_instance_matches(minecraft_root: Path, instance_name: str) -> list[Shul
     return matches
 
 
-def load_shulker_box_matches(
+def get_instances_matching_shulker_box(
     minecraft_root: Path, shulker_box_name: str
 ) -> list[InstanceSpec]:
     """Get the list of registered instances that link to the specified shulker box

--- a/enderchest/gather.py
+++ b/enderchest/gather.py
@@ -292,6 +292,27 @@ def load_ender_chest_remotes(
     return remote_list
 
 
+def load_instance_matches(
+    minecraft_root: Path, instance_name: str
+) -> Sequence[ShulkerBox]:
+    """Get the list of shulker boxes that the specified instance links to
+
+    Parameters
+    ----------
+    minecraft_root : Path
+        The root directory that your minecraft stuff (or, at least, the one
+        that's the parent of your EnderChest folder)
+    instance_name : str
+        The name of the instance you're asking about
+
+    Returns
+    -------
+    list of ShulkerBox
+        The shulker boxes that are linked to by the specified instance
+    """
+    raise NotImplementedError
+
+
 def load_shulker_box_matches(
     minecraft_root: Path, shulker_box_name: str
 ) -> Sequence[InstanceSpec]:

--- a/enderchest/test/test_cli.py
+++ b/enderchest/test/test_cli.py
@@ -355,6 +355,11 @@ class TestGatherRemote(ActionTestSuite):
         )
 
 
+class TestInstanceInventory(ActionTestSuite):
+    action = "inventory minecraft"
+    required_args = ("cherry grove",)
+
+
 class TestShulkerInventory(ActionTestSuite):
     action = "inventory shulker_box"
     required_args = ("nombre",)

--- a/enderchest/test/test_gather.py
+++ b/enderchest/test/test_gather.py
@@ -92,7 +92,10 @@ class TestLoadBoxInstanceMatches:
                 if should_match:
                     expected.append(box_lookup[box_name])
 
-        assert gather.load_instance_matches(minecraft_root, instance_name) == expected
+        assert (
+            gather.get_shulker_boxes_matching_instance(minecraft_root, instance_name)
+            == expected
+        )
 
     @pytest.mark.parametrize(
         "shulker_box_name",
@@ -120,7 +123,7 @@ class TestLoadBoxInstanceMatches:
                     expected.append(instance_lookup[instance_name])
 
         assert (
-            gather.load_shulker_box_matches(minecraft_root, shulker_box_name)
+            gather.get_instances_matching_shulker_box(minecraft_root, shulker_box_name)
             == expected
         )
 


### PR DESCRIPTION
## Summary
<!--- One sentence summary of this PR. Can oftentimes just be a matter of linking
      to the issue number --->

Implements #59

## List of Changes
<!--- List out the changes introduced by this PR, permalinking
      (read: with commit hash) to the commit, file or section of code where
      that change was implemented --->

* separates out the verb: `enderchest inventory minecraft` from `enderchest inventory minecrafts` so that calling `enderchest inventory minecraft "My Instance"` gives you the list of shulker boxes that get linked to by that instance
* and yes, to be clear, to just get the full list of instances, the verb is [`enderchest inventory minecrafts`](openbagtwo.github.io/EnderChest/dev/cli/#enderchest-inventory-minecrafts) which... I am not exactly defending here
* on a positive note, I did some refactoring to make the _internal_ names less confusing
* ... and added a bunch of tests for the inventory behavior

## Tech Debt and Other Concerns
<!--- Use this section to call out anything in the code (including stuff you
      discovered outside of your contributions!) that you think may cause
      issues either now or further down the road. These will need to be spun
      off into issues before the PR is closed but shouldn't impede you opening
      the PR and starting the review process --->


<!--- Un-comment this section if this is still a work in progress. When doing
      so, please be sure to add (WIP), (Draft) or (DNM) in the PR title and
      open this PR as a draft

## To Do

--->


## Validation Performed
<!--- What did you do to ensure that this change is behaving as intended? This
should start with unit tests, but it's usually a good idea to try running
the code in a real setting. Include screenshots if you'd like, but make sure to
remove any personal information you won't want to share --->

## PR Type
<!--- Check all that apply --->
- [ ] This PR introduces a breaking change (will
  [require a bump in the minor version](https://semver.org/)) (I mean, technically the change is breaking, but it's literally the difference of adding an "s," and the `inventory` commands aren't documented anywhere besides the CLI docs)
- [ ] The changes in this PR are high urgency and necessitate a hotfix or patch
  release (will require rebasing off of `release`)
- [ ] This is a release (staging) PR (maintainer use only)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.
      All bullets in this section are required to be checked off before the PR can
      be merged, but they don't need to be checked off before the PR is opened.
      If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] I have read [the contributor's guide](https://openbagtwo.github.io/EnderChest/dev/contrib/)
- [x] I have run `mkdocs serve` locally and ensured that all API docs and
  changes I have made to the static pages are rendering correctly, with all links
  working
- [x] All tech debt concerns have been resolved, documented as issues, or otherwise
  accepted
- [x] I agree to license my contribution to this project under
  [the GNU Public License v3](https://www.gnu.org/licenses/gpl-3.0.en.html)
  <!--- If you wish to use a different compatible license, please edit the above--->


<!--- Adapted from https://github.com/stevemao/github-issue-templates --->
