### PR TITLE
Fully resolve nested symlinks in `absolute` mode

### DIFF
--- a/enderchest/place.py
+++ b/enderchest/place.py
@@ -310,10 +310,10 @@ def link_resource(
     instance_path.parent.mkdir(parents=True, exist_ok=True)
 
     target: str | Path = (shulker_root / resource_path).expanduser().absolute()
-    if not relative:
-        target = target.resolve()  # type: ignore
     if relative:
         target = os.path.relpath(target, instance_path.parent)
+    else:
+        target = target.resolve()  # type: ignore
 
     if instance_path.is_symlink():
         # remove previous symlink in this spot

--- a/enderchest/place.py
+++ b/enderchest/place.py
@@ -310,6 +310,8 @@ def link_resource(
     instance_path.parent.mkdir(parents=True, exist_ok=True)
 
     target: str | Path = (shulker_root / resource_path).expanduser().absolute()
+    if not relative:
+        target = target.resolve()  # type: ignore
     if relative:
         target = os.path.relpath(target, instance_path.parent)
 

--- a/enderchest/test/test_place.py
+++ b/enderchest/test/test_place.py
@@ -209,9 +209,13 @@ class TestSingleShulkerPlace:
 
         instance_folder = utils.resolve(instance.root, minecraft_root)
 
-        assert os.path.abspath(os.readlink(instance_folder / "saves" / "test")) == str(
-            minecraft_root / "worlds" / "testbench"
-        )
+        link_target = os.path.abspath(os.readlink(instance_folder / "saves" / "test"))
+
+        # Windows shenanigans: https://bugs.python.org/issue42957
+        if link_target.startswith(("\\\\?\\", "\\??\\")):  # pragma: no cover
+            link_target = link_target[4:]
+
+        assert link_target == str(minecraft_root / "worlds" / "testbench")
 
     @utils.parametrize_over_instances("axolotl", "bee")
     def test_place_cleans_up_broken_symlinks_by_default(self, minecraft_root, instance):


### PR DESCRIPTION
## Summary
<!--- One sentence summary of this PR. Can oftentimes just be a matter of linking
      to the issue number --->

I upgraded one of my worlds to 1.20.1, and it looks like Mojang is now testing not just the direct target but is _fully resolving_ the link... while still not resolving relative paths.

This patch PR changes the behavior when placing with `relative=False` (the CLI default) so that absolute links are fully resolved.

## List of Changes
<!--- List out the changes introduced by this PR, permalinking
      (read: with commit hash) to the commit, file or section of code where
      that change was implemented --->

* Fully resolves links when placing in absolute mode
* Adds notes to the API docs explaining that this will have some (as far as I can tell, unavoidable) consequences when cleaning up stale links
* Adds tests covering this new behavior (and some other nuances of the place operation)
* A little bit of code simplification (`NotADirectoryError` is a subclass of `OSError`! Who knew!)

## Tech Debt and Other Concerns
<!--- Use this section to call out anything in the code (including stuff you
      discovered outside of your contributions!) that you think may cause
      issues either now or further down the road. These will need to be spun
      off into issues before the PR is closed but shouldn't impede you opening
      the PR and starting the review process --->


<!--- Un-comment this section if this is still a work in progress. When doing
      so, please be sure to add (WIP), (Draft) or (DNM) in the PR title and
      open this PR as a draft

## To Do

--->


## Validation Performed
<!--- What did you do to ensure that this change is behaving as intended? This
should start with unit tests, but it's usually a good idea to try running
the code in a real setting. Include screenshots if you'd like, but make sure to
remove any personal information you won't want to share --->
* Added new tests to cover the absolute pathing
* Used this version of EnderChest to `place` my symlinks for a 1.20.1 instance and verified that the save game that refused to load earlier (because the second hop of the link was a relative link) would now load.

## PR Type
<!--- Check all that apply --->
- [ ] This PR introduces a breaking change (will
  [require a bump in the minor version](https://semver.org/))
- [x] The changes in this PR are high urgency and necessitate a hotfix or patch
  release (will require rebasing off of `release`)
- [ ] This is a release (staging) PR (maintainer use only)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.
      All bullets in this section are required to be checked off before the PR can
      be merged, but they don't need to be checked off before the PR is opened.
      If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] I have read [the contributor's guide](https://openbagtwo.github.io/EnderChest/dev/contrib/)
- [x] I have run `mkdocs serve` locally and ensured that all API docs and
  changes I have made to the static pages are rendering correctly, with all links
  working
- [x] All tech debt concerns have been resolved, documented as issues, or otherwise
  accepted
- [x] I agree to license my contribution to this project under
  [the GNU Public License v3](https://www.gnu.org/licenses/gpl-3.0.en.html)
  <!--- If you wish to use a different compatible license, please edit the above--->


<!--- Adapted from https://github.com/stevemao/github-issue-templates --->
