### PR TITLE
Mock Paramiko calls using cached SFTPAttributes

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -57,7 +57,7 @@ jobs:
       run: |
         mkdir -p sandbox
         cd sandbox
-        python -m pytest -vv --pyargs enderchest.test --doctest-modules --ignore-glob="docs/**" --log-level=DEBUG --use-local-ssh
+        python -m pytest -vv -p enderchest.test.plugin --pyargs enderchest.test --doctest-modules --ignore-glob="docs/**" --log-level=DEBUG --use-local-ssh
     - name: Run unit tests (using mock SSH)
       if: matrix.os == 'windows-latest'
       run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -25,7 +25,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         py: ['3.10', '3.11']
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -52,7 +52,14 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install .[test,sftp]
-    - name: Run unit tests
+    - name: Run unit tests (using local SSH)
+      if: matrix.os != 'windows-latest'
+      run: |
+        mkdir -p sandbox
+        cd sandbox
+        python -m pytest -vv --pyargs enderchest.test --doctest-modules --ignore-glob="docs/**" --log-level=DEBUG --use-local-ssh
+    - name: Run unit tests (using mock SSH)
+      if: matrix.os == 'windows-latest'
       run: |
         mkdir -p sandbox
         cd sandbox

--- a/docs/contrib.md
+++ b/docs/contrib.md
@@ -131,6 +131,38 @@ variety of
 and [fixtures](https://github.com/OpenBagTwo/EnderChest/blob/dev/enderchest/test/conftest.py)
 are available for you to leverage for help mocking out file systems.
 
+### Tests Requiring SSH
+
+SFTP syncing was originally tested against an SSH server running locally that
+could be authenticated against passwordlessly. To remove the requirement that
+developers have their systems set up similarly, these tests now default to
+[mocking the calls to paramiko](https://github.com/OpenBagTwo/EnderChest/blob/dev/enderchest/test/mock_paramiko.py)
+using
+[cached SFTP attributes](https://github.com/OpenBagTwo/EnderChest/blob/dev/enderchest/test/testing_files/lstat_cache.json).
+
+If you make any changes or additions to the "remote" file system used by these
+tests, this cache will need to be regenerated, and for that you will need to
+set up SSH for local passwordless authentication.
+
+!!! tip
+    A good example for configuring key-based passwordless SSH on a POSIX
+    system can be found in
+    [our GitHub Actions](https://github.com/OpenBagTwo/EnderChest/blob/paramiko/.github/workflows/pull_request.yml#L40-L47).
+
+The current procedure to regenerate that cache is:
+
+1. Un-comment [this unit test](https://github.com/OpenBagTwo/EnderChest/blob/853bdbac76124fb9e6d4a754f4dd73c48e66d829/enderchest/test/test_sync.py#L542-L545)
+1. Run
+   ```bash
+   pytest enderchest/tests/test_sync.py::TestSFTPSync::test_generate_lstat_cache --use-local-ssh
+   ```
+1. Re-comment-out that test, then make sure the cache is working by running
+   ```bash
+   pytest -vvx enderchest/tests/test_sync.py::TestSFTPSync
+   ```
+1. If all tests pass when using the cache, then make sure to `git add` the
+   regenerated testing file and include it in your next commit
+
 ## Documentation
 
 In addition to internal (docstring) documentation, the EnderChest project includes

--- a/enderchest/sync/utils.py
+++ b/enderchest/sync/utils.py
@@ -189,7 +189,7 @@ def filter_contents(
     for path_info in contents:
         if not any(
             (
-                fnmatch.fnmatchcase(
+                fnmatch.fnmatch(
                     os.path.normpath(os.path.join(prefix or "", path_info[0])),
                     os.path.join("*", pattern),
                 )

--- a/enderchest/sync/utils.py
+++ b/enderchest/sync/utils.py
@@ -40,8 +40,7 @@ def path_from_uri(uri: ParseResult) -> Path:
     Path
         The path part of the URI as a Path
     """
-    host = "{0}{0}{mnt}{0}".format(os.path.sep, mnt=uri.netloc)
-    return Path(os.path.abspath(os.path.join(host, url2pathname(unquote(uri.path)))))
+    return Path(url2pathname(unquote(uri.path)))
 
 
 def uri_to_ssh(uri: ParseResult) -> str:

--- a/enderchest/test/conftest.py
+++ b/enderchest/test/conftest.py
@@ -1,5 +1,4 @@
 """Useful setup / teardown fixtures"""
-import os
 from importlib.resources import as_file
 from pathlib import Path
 

--- a/enderchest/test/conftest.py
+++ b/enderchest/test/conftest.py
@@ -9,6 +9,26 @@ from .testing_files import CLIENT_OPTIONS
 from .utils import populate_instances_folder, populate_official_minecraft_folder
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--use-local-ssh",
+        action="store_true",
+        default=False,
+        help=(
+            "By default, SFTP tests are run against a mock SSH server."
+            " If your system happens to be set up for passwordless sshing"
+            " into localhost, you can choose to run your tests against your"
+            " actual SSH server by using this flag."
+        ),
+    )
+
+
+@pytest.fixture
+def use_local_ssh(request):
+    """h/t https://stackoverflow.com/a/55003726"""
+    return request.config.getoption("--use-local-ssh")
+
+
 @pytest.fixture
 def file_system(tmp_path):
     """Create a testing file system and throw a bunch of random files across

--- a/enderchest/test/conftest.py
+++ b/enderchest/test/conftest.py
@@ -9,26 +9,12 @@ from .testing_files import CLIENT_OPTIONS
 from .utils import populate_instances_folder, populate_official_minecraft_folder
 
 
-def pytest_addoption(parser):
-    parser.addoption(
-        "--use-local-ssh",
-        action="store_true",
-        default=False,
-        help=(
-            "By default, SFTP tests are run against a mock SSH server."
-            " If your system happens to be set up for passwordless sshing"
-            " into localhost, you can choose to run your tests against your"
-            " actual SSH server by using this flag."
-        ),
-    )
-
-
 @pytest.fixture
 def use_local_ssh(request):
     """h/t https://stackoverflow.com/a/55003726
     (though it's also in the pytest docs lol)
     """
-    return request.config.getoption("--use-local-ssh")
+    return request.config.getoption("--use-local-ssh", False)
 
 
 @pytest.fixture

--- a/enderchest/test/conftest.py
+++ b/enderchest/test/conftest.py
@@ -25,7 +25,9 @@ def pytest_addoption(parser):
 
 @pytest.fixture
 def use_local_ssh(request):
-    """h/t https://stackoverflow.com/a/55003726"""
+    """h/t https://stackoverflow.com/a/55003726
+    (though it's also in the pytest docs lol)
+    """
     return request.config.getoption("--use-local-ssh")
 
 

--- a/enderchest/test/mock_paramiko.py
+++ b/enderchest/test/mock_paramiko.py
@@ -1,0 +1,126 @@
+"""A mock Paramiko SFTP client to be used for testing on systems without local SSH"""
+import json
+import shutil
+from contextlib import contextmanager
+from importlib.resources import as_file
+from pathlib import Path
+from typing import Callable, Generator, NamedTuple
+from urllib.parse import ParseResult
+
+from .testing_files import LSTAT_CACHE
+
+
+class CachedStat(NamedTuple):
+    filename: str
+    st_mode: int
+    st_size: float
+    st_mtime: float
+
+
+class MockSFTP:
+    """Create a mock SFTP client suitable for testing
+
+    Parameters
+    ----------
+    root : Path
+        The top-most directory that will be accessed by this client (this
+        corresponds to the path in the remote URI for the EnderChest)
+    """
+
+    def __init__(self, root: Path):
+        with as_file(LSTAT_CACHE) as lstat_cache_file:
+            cached_lstats: list[dict] = json.loads(lstat_cache_file.read_text())
+
+        self.lstat_cache: dict[Path, CachedStat] = {
+            root / stat["filename"]: CachedStat(**stat) for stat in cached_lstats
+        }
+
+    def lstat(self, path: str) -> CachedStat:
+        """Return the cached file attributes for the specified path"""
+        try:
+            return self.lstat_cache[Path(path)]
+        except KeyError:
+            """In a few places we get an lstat on a directory (that's not included
+            in the rglob). Rather than including them in the cache, we're just
+            going to mock out that they're directories."""
+            return CachedStat(filename="", st_mode=16877, st_size=-1, st_mtime=-1)
+
+    def mkdir(self, path: str) -> None:
+        """Make a directory on the "remote" file system"""
+        Path(path).mkdir()
+
+    def symlink(self, target: str, path: str) -> None:
+        """Create a symlink at the path pointing to the target"""
+        Path(path).symlink_to(Path(target))
+
+    def readlink(self, path: str) -> str:
+        """Get the target of the "remote" symlink"""
+        return Path(path).readlink().as_posix()
+
+    def get(self, path: str, destination: Path) -> None:
+        """ "Download" the "remote" file to the specified destination"""
+        shutil.copy2(
+            Path(path),
+            destination,
+            follow_symlinks=False,
+        )
+
+    def put(self, source: Path, path: str) -> None:
+        """ "Upload" the "remote" file to the specified destination"""
+        shutil.copy2(
+            source,
+            Path(path),
+            follow_symlinks=False,
+        )
+
+    def remove(self, path: str) -> None:
+        """Delete a file on the "remote" file system"""
+        Path(path).unlink()
+
+    def rmdir(self, path: str) -> None:
+        """Delete an empty folder on the "remote" file system"""
+        Path(path).rmdir()
+
+
+def generate_mock_connect(mock_sftp: MockSFTP) -> Callable:
+    """Create a method suitable to be used as a monkeypatch for `sync.sftp.connect`
+    that instead yields the provided MockSFTP instance
+
+    Parameters
+    ----------
+    mock_sftp : MockSFTP
+        The mock SFTP client the method should connect to instead
+
+    Returns
+    -------
+    Method
+        A method suitable for use in monkeypatching `sync.sftp.connect`
+    """
+
+    @contextmanager
+    def connect(
+        uri: ParseResult, timeout: float | None = None
+    ) -> Generator[MockSFTP, None, None]:
+        yield mock_sftp
+
+    return connect
+
+
+def mock_rglob(client: MockSFTP, path: str) -> list[tuple[Path, CachedStat]]:
+    """A method that simulates `sync.sftp.rglob` by relying on the
+    `lstat_cache` of the client instead of actually recursively getting the
+    file attributes of the given path
+
+    Parameters
+    ----------
+    client : MockSFTP
+        The mock SFTP client
+    path : str
+        This parameter is ignored
+
+    Returns
+    -------
+    list of (Path, SFTPAttributes-like) tuples
+        The cached file attributes
+    """
+    return list(client.lstat_cache.items())

--- a/enderchest/test/mock_paramiko.py
+++ b/enderchest/test/mock_paramiko.py
@@ -11,6 +11,8 @@ from .testing_files import LSTAT_CACHE
 
 
 class CachedStat(NamedTuple):
+    """Stat-like loaded from a file cache"""
+
     filename: str
     st_mode: int
     st_size: float
@@ -29,7 +31,7 @@ class MockSFTP:
 
     def __init__(self, root: Path):
         with as_file(LSTAT_CACHE) as lstat_cache_file:
-            cached_lstats: list[dict] = json.loads(lstat_cache_file.read_text())
+            cached_lstats: list[dict] = json.loads(lstat_cache_file.read_text("UTF-8"))
 
         self.lstat_cache: dict[Path, CachedStat] = {
             root / stat["filename"]: CachedStat(**stat) for stat in cached_lstats
@@ -40,9 +42,9 @@ class MockSFTP:
         try:
             return self.lstat_cache[Path(path)]
         except KeyError:
-            """In a few places we get an lstat on a directory (that's not included
-            in the rglob). Rather than including them in the cache, we're just
-            going to mock out that they're directories."""
+            # In a few places we get an lstat on a directory (that's not included
+            # in the rglob). Rather than including them in the cache, we're just
+            # going to mock out that they're directories.
             return CachedStat(filename="", st_mode=16877, st_size=-1, st_mtime=-1)
 
     def mkdir(self, path: str) -> None:

--- a/enderchest/test/plugin.py
+++ b/enderchest/test/plugin.py
@@ -1,0 +1,15 @@
+"""Additional pytest CLI options. h/t https://stackoverflow.com/a/52458082"""
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--use-local-ssh",
+        action="store_true",
+        default=False,
+        help=(
+            "By default, SFTP tests are run against a mock SSH server."
+            " If your system happens to be set up for passwordless sshing"
+            " into localhost, you can choose to run your tests against your"
+            " actual SSH server by using this flag."
+        ),
+    )

--- a/enderchest/test/test_sync.py
+++ b/enderchest/test/test_sync.py
@@ -504,15 +504,16 @@ class TestSFTPSync(TestFileSync):
     protocol = "sftp"
 
     @pytest.fixture(autouse=True)
-    def patch_paramiko(self, remote, monkeypatch):
-        from enderchest.sync import sftp
+    def patch_paramiko(self, remote, monkeypatch, use_local_ssh):
+        if use_local_ssh:
+            from enderchest.sync import sftp
 
-        mock_sftp = mock_paramiko.MockSFTP(path_from_uri(remote) / "EnderChest")
+            mock_sftp = mock_paramiko.MockSFTP(path_from_uri(remote) / "EnderChest")
 
-        monkeypatch.setattr(
-            sftp, "connect", mock_paramiko.generate_mock_connect(mock_sftp)
-        )
-        monkeypatch.setattr(sftp, "rglob", mock_paramiko.mock_rglob)
+            monkeypatch.setattr(
+                sftp, "connect", mock_paramiko.generate_mock_connect(mock_sftp)
+            )
+            monkeypatch.setattr(sftp, "rglob", mock_paramiko.mock_rglob)
 
     @pytest.fixture(autouse=False)
     def generate_lstat_cache(self, remote):

--- a/enderchest/test/test_sync.py
+++ b/enderchest/test/test_sync.py
@@ -505,7 +505,7 @@ class TestSFTPSync(TestFileSync):
 
     @pytest.fixture(autouse=True)
     def patch_paramiko(self, remote, monkeypatch, use_local_ssh):
-        if use_local_ssh:
+        if not use_local_ssh:
             from enderchest.sync import sftp
 
             mock_sftp = mock_paramiko.MockSFTP(path_from_uri(remote) / "EnderChest")

--- a/enderchest/test/test_sync.py
+++ b/enderchest/test/test_sync.py
@@ -336,7 +336,7 @@ class TestFileSync:
         assert "Could not sync changes with prayer://unreachable" in warnings[0]
 
 
-@pytest.mark.xfail(
+@pytest.mark.skipif(
     not shutil.which("rsync"), reason="rsync is not installed on this system"
 )
 class TestRsyncSync(TestFileSync):
@@ -497,7 +497,7 @@ def _is_paramiko_installed() -> bool:
 PARAMIKO_INSTALLED = _is_paramiko_installed()
 
 
-@pytest.mark.xfail(
+@pytest.mark.skipif(
     not PARAMIKO_INSTALLED, reason="EnderChest was not installed with SFTP support"
 )
 class TestSFTPSync(TestFileSync):

--- a/enderchest/test/testing_files/__init__.py
+++ b/enderchest/test/testing_files/__init__.py
@@ -4,6 +4,7 @@ from importlib.resources import files
 __all__ = [
     "CLIENT_OPTIONS",
     "ENDERCHEST_CONFIG",
+    "LSTAT_CACHE",
     "INSTGROUPS",
     "LAUNCHER_PROFILES",
     "VERSION_MANIFEST",
@@ -14,6 +15,8 @@ _here = files(__package__)
 CLIENT_OPTIONS = _here / "options.txt"
 
 ENDERCHEST_CONFIG = _here / "enderchest.cfg"
+
+LSTAT_CACHE = _here / "lstat_cache.json"
 
 INSTGROUPS = _here / "instgroups.json"
 

--- a/enderchest/test/testing_files/lstat_cache.json
+++ b/enderchest/test/testing_files/lstat_cache.json
@@ -1,0 +1,104 @@
+[
+    {
+        "filename": "enderchest.cfg",
+        "st_mode": 33188,
+        "st_size": 988,
+        "st_mtime": 1694478556
+    },
+    {
+        "filename": "steamdeck",
+        "st_mode": 16877,
+        "st_size": 60,
+        "st_mtime": 1694478556
+    },
+    {
+        "filename": "steamdeck/shulkerbox.cfg",
+        "st_mode": 33188,
+        "st_size": 73,
+        "st_mtime": 1694478556
+    },
+    {
+        "filename": "optifine",
+        "st_mode": 16877,
+        "st_size": 80,
+        "st_mtime": 1694478556
+    },
+    {
+        "filename": "optifine/mods",
+        "st_mode": 16877,
+        "st_size": 60,
+        "st_mtime": 1694478556
+    },
+    {
+        "filename": "optifine/mods/optifine.jar",
+        "st_mode": 33188,
+        "st_size": 9,
+        "st_mtime": 1694478556
+    },
+    {
+        "filename": "optifine/shulkerbox.cfg",
+        "st_mode": 33188,
+        "st_size": 173,
+        "st_mtime": 1694478556
+    },
+    {
+        "filename": "vanilla",
+        "st_mode": 16877,
+        "st_size": 80,
+        "st_mtime": 1694478556
+    },
+    {
+        "filename": "vanilla/conflict",
+        "st_mode": 16877,
+        "st_size": 60,
+        "st_mtime": 1694478556
+    },
+    {
+        "filename": "vanilla/conflict/diamond.png",
+        "st_mode": 33188,
+        "st_size": 10,
+        "st_mtime": 1694478556
+    },
+    {
+        "filename": "vanilla/shulkerbox.cfg",
+        "st_mode": 33188,
+        "st_size": 126,
+        "st_mtime": 1694478556
+    },
+    {
+        "filename": "1.19",
+        "st_mode": 16877,
+        "st_size": 100,
+        "st_mtime": 1694478556
+    },
+    {
+        "filename": "1.19/.bobby",
+        "st_mode": 16877,
+        "st_size": 60,
+        "st_mtime": 1694478556
+    },
+    {
+        "filename": "1.19/.bobby/chunk",
+        "st_mode": 33188,
+        "st_size": 7,
+        "st_mtime": 1694478556
+    },
+    {
+        "filename": "1.19/saves",
+        "st_mode": 16877,
+        "st_size": 60,
+        "st_mtime": 1694478556
+    },
+    {
+        "filename": "1.19/saves/olam",
+        "st_mode": 41471,
+        "st_size": 97,
+        "st_mtime": 1694478556
+    },
+    {
+        "filename": "1.19/shulkerbox.cfg",
+        "st_mode": 33188,
+        "st_size": 139,
+        "st_mtime": 1694478556
+    }
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,5 +22,8 @@ profile = black
 max-line-length = 88
 extend-ignore = E203
 
+[tool:pytest]
+addopts = -p enderchest.test.plugin
+
 [coverage:run]
 omit = enderchest/test/*, enderchest/_version.py


### PR DESCRIPTION
Going about the Windows testing support a different way that also won't require local users to be set up for passwordless SSH into their own machines in order to run the unit tests.

What I've done is added a fixture that replaces the SFTP client with a mock client that just implements everything as file operations and then just uses a static cache of SFTP Attributes to compute all the diffs.

The end goal is going to be a pytest flag that allows developers or end-users to control whether they run the tests against a mock SFTP server or the real one. And then since I've got local-ssh set up on my POSIX runners already, I'll then go ahead and only use the mock settings for Windows (and as the default for end-users).

I'm still trying to work out the best way to regenerate the "`LSTAT_CACHE`," as un-commenting a test line seems rather crude...