### PR TITLE
Separate "groups" from "tags"

### DIFF
--- a/enderchest/enderchest.py
+++ b/enderchest/enderchest.py
@@ -163,6 +163,8 @@ class EnderChest:
                 matching_instances.append(old_instance)
                 self._instances.remove(old_instance)
 
+        instance = i.merge(*matching_instances, instance)
+
         name = instance.name
         counter = 0
         taken_names = {old_instance.name for old_instance in self._instances}
@@ -172,10 +174,8 @@ class EnderChest:
             counter += 1
             name = f"{instance.name}.{counter}"
 
-        instance = i.merge(*matching_instances, instance)
-
         GATHER_LOGGER.debug(f"Registering instance {instance.name} at {instance.root}")
-        self._instances.append(instance._replace(name=name))
+        self._instances.append(instance)
         return self._instances[-1]
 
     @property

--- a/enderchest/enderchest.py
+++ b/enderchest/enderchest.py
@@ -157,11 +157,12 @@ class EnderChest:
         - If this instance shares a path with an existing instance, it will
           replace that instance
         """
-        self._instances = [
-            old_instance
-            for old_instance in self._instances
-            if not i.equals(abspath_from_uri(self._uri), instance, old_instance)
-        ]
+        matching_instances: list[i.InstanceSpec] = []
+        for old_instance in self._instances:
+            if i.equals(abspath_from_uri(self._uri), instance, old_instance):
+                matching_instances.append(old_instance)
+                self._instances.remove(old_instance)
+
         name = instance.name
         counter = 0
         taken_names = {old_instance.name for old_instance in self._instances}
@@ -170,6 +171,8 @@ class EnderChest:
                 break
             counter += 1
             name = f"{instance.name}.{counter}"
+
+        instance = i.merge(*matching_instances, instance)
 
         GATHER_LOGGER.debug(f"Registering instance {instance.name} at {instance.root}")
         self._instances.append(instance._replace(name=name))

--- a/enderchest/enderchest.py
+++ b/enderchest/enderchest.py
@@ -347,7 +347,8 @@ class EnderChest:
                 "root": instance.root,
                 "minecraft-version": instance.minecraft_versions,
                 "modloader": instance.modloader,
-                "tags": instance.tags,
+                "groups": instance.groups_,
+                "tags": instance.tags_,
             }
 
         config = cfg.dumps(

--- a/enderchest/gather.py
+++ b/enderchest/gather.py
@@ -232,7 +232,7 @@ def _render_shulker_box(shulker_box: ShulkerBox) -> str:
             (if different from folder name)
     """
     stringified = f"{shulker_box.root.name}"
-    if shulker_box.root.name != shulker_box.name:
+    if shulker_box.root.name != shulker_box.name:  # pragma: no cover
         # note: this is not a thing
         stringified += f" ({shulker_box.name})"
     return stringified

--- a/enderchest/gather.py
+++ b/enderchest/gather.py
@@ -91,7 +91,7 @@ def load_ender_chest_instances(
         GATHER_LOGGER.log(
             log_level,
             "These are the instances that are currently registered"
-            f" to the {minecraft_root} EnderChest:\n %s",
+            f" to the {minecraft_root} EnderChest:\n%s",
             "\n".join(
                 [
                     f"  {i + 1}. {_render_instance(instance)}"

--- a/enderchest/gather.py
+++ b/enderchest/gather.py
@@ -574,17 +574,17 @@ def gather_metadata_for_official_instance(
         version_lookup = {}
 
     versions: list[str] = []
-    tags: list[str] = ["vanilla"]
+    groups: list[str] = ["vanilla"]
     for version in raw_versions:
         if version.startswith("latest-"):
             mapped_version = version_lookup.get(version[len("latest-") :])
             if mapped_version is not None:
                 versions.append(parse_version(mapped_version))
-                tags.append(version)
+                groups.append(version)
                 continue
         versions.append(parse_version(version))
 
-    return InstanceSpec(name, minecraft_folder, tuple(versions), "", tuple(tags))
+    return InstanceSpec(name, minecraft_folder, tuple(versions), "", tuple(groups), ())
 
 
 def gather_metadata_for_mmc_instance(
@@ -653,7 +653,7 @@ def gather_metadata_for_mmc_instance(
 
     name = minecraft_folder.parent.name
 
-    tags: list[str] = []
+    instance_groups: list[str] = []
 
     if name == "":
         GATHER_LOGGER.warning(
@@ -668,10 +668,10 @@ def gather_metadata_for_mmc_instance(
         try:
             with instgroups_file.open() as groups_json:
                 groups: dict[str, dict] = json.load(groups_json)["groups"]
-            for tag, metadata in groups.items():
+            for group, metadata in groups.items():
                 # interestingly this comes from the folder name, not the actual name
                 if name in metadata.get("instances", ()):
-                    tags.append(tag)
+                    instance_groups.append(group)
 
         except FileNotFoundError as no_json:
             GATHER_LOGGER.warning(
@@ -709,7 +709,8 @@ def gather_metadata_for_mmc_instance(
         minecraft_folder,
         (version,),
         modloader or "",
-        tuple(tags),
+        tuple(instance_groups),
+        (),
     )
 
 

--- a/enderchest/instance.py
+++ b/enderchest/instance.py
@@ -23,14 +23,16 @@ class InstanceSpec(NamedTuple):
     modloader : str
         The (display) name of the modloader (vanilla corresponds to "")
     tags : list-like of str
-        The tags assigned to this instance
+        The tags assigned to this instance, including both the ones assigned
+        in the launcher (groups) and the ones assigned by hand.
     """
 
     name: str
     root: Path
     minecraft_versions: tuple[str, ...]
     modloader: str
-    tags: tuple[str, ...]
+    groups_: tuple[str, ...]
+    tags_: tuple[str, ...]
 
     @classmethod
     def from_cfg(cls, section: SectionProxy) -> "InstanceSpec":
@@ -63,8 +65,13 @@ class InstanceSpec(NamedTuple):
                 )
             ),
             normalize_modloader(section.get("modloader", None))[0],
+            tuple(cfg.parse_ini_list(section.get("groups", ""))),
             tuple(cfg.parse_ini_list(section.get("tags", ""))),
         )
+
+    @property
+    def tags(self):
+        return tuple(sorted({*self.groups_, *self.tags_}))
 
 
 def normalize_modloader(loader: str | None) -> list[str]:

--- a/enderchest/instance.py
+++ b/enderchest/instance.py
@@ -170,6 +170,13 @@ def merge(*instances: InstanceSpec) -> InstanceSpec:
     -------
     InstanceSpec
         The merged instance
+
+    Notes
+    -----
+    The resulting merged instance will use:
+      - the first instance's name
+      - the union of all non-group tags
+      - all other data from the last instance
     """
     try:
         combined_instance = instances[-1]
@@ -178,4 +185,4 @@ def merge(*instances: InstanceSpec) -> InstanceSpec:
             "Must provide at least one instance to merge"
         ) from nothing_to_merge
     tags = tuple(sorted(set(sum((instance.tags_ for instance in instances), ()))))
-    return combined_instance._replace(tags_=tags)
+    return combined_instance._replace(name=instances[0].name, tags_=tags)

--- a/enderchest/instance.py
+++ b/enderchest/instance.py
@@ -155,3 +155,27 @@ def parse_version(version_string: str) -> str:
     if re.match(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)$", version_string):
         return version_string + ".0"
     return version_string
+
+
+def merge(*instances: InstanceSpec) -> InstanceSpec:
+    """Merge multiple instances, layering information from the ones provided later
+    on top of the ones provided earlier
+
+    Parameters
+    ----------
+    *instances : InstanceSpec
+        The instances to combine
+
+    Returns
+    -------
+    InstanceSpec
+        The merged instance
+    """
+    try:
+        combined_instance = instances[-1]
+    except IndexError as nothing_to_merge:
+        raise ValueError(
+            "Must provide at least one instance to merge"
+        ) from nothing_to_merge
+    tags = tuple(sorted(set(sum((instance.tags_ for instance in instances), ()))))
+    return combined_instance._replace(tags_=tags)

--- a/enderchest/test/test_config.py
+++ b/enderchest/test/test_config.py
@@ -110,6 +110,7 @@ class TestConfigWriting:
                     Path("..") / "instances" / "puppet" / ".minecraft",
                     ("1.20.1-pre1",),
                     "vanilla",
+                    (),
                     ("your", "it"),
                 ),
             ),

--- a/enderchest/test/test_instance.py
+++ b/enderchest/test/test_instance.py
@@ -62,7 +62,8 @@ class TestInstanceMerging:
         assert original == merged
 
     @pytest.mark.parametrize(
-        "field", (field for field in i.InstanceSpec._fields if field != "tags_")
+        "field",
+        (field for field in i.InstanceSpec._fields if field not in ("name", "tags_")),
     )
     def test_merged_fields_mostly_match_the_last_instance(self, field):
         instances = [
@@ -84,7 +85,20 @@ class TestInstanceMerging:
 
         assert getattr(merged, field) == getattr(instances[-1], field)
 
-    def test_merged_fields_are_the_union_of_all_instance_tags(self):
+    def test_merged_name_matches_the_first_instance(self):
+        instances = [
+            instance("one", Path("path"), tags=("you're it",)),
+            instance("two", Path("path"), tags=("hello", "friend")),
+            instance("three", Path("path"), tags=("hello", "world")),
+            instance("four", Path("path"), tags=("best", "friend")),
+            instance("five", Path("path")),
+        ]
+
+        merged = i.merge(*instances)
+
+        assert merged.name == "one"
+
+    def test_merged_tags_are_the_union_of_all_instance_tags(self):
         instances = [
             instance("one", Path("path"), tags=("you're it",)),
             instance("two", Path("path"), tags=("hello", "friend")),

--- a/enderchest/test/test_instance.py
+++ b/enderchest/test/test_instance.py
@@ -46,6 +46,10 @@ class TestInstanceEquality:
 
 
 class TestInstanceMerging:
+    def test_supplying_no_instances_raises_a_sensible_error(self):
+        with pytest.raises(ValueError, match="at least one instance"):
+            i.merge()
+
     def test_merging_a_single_instance_results_in_a_copy(self):
         original = instance(
             name="an instance",
@@ -70,7 +74,9 @@ class TestInstanceMerging:
             instance("one", Path("path"), minecraft_versions=("1.20.2",)),
             instance(
                 "two",
-                Path("path", modloader="blacksmith", groups=("forgery",)),
+                Path("path"),
+                modloader="blacksmith",
+                groups=("forgery",),
                 tags=("you're it",),
             ),
             instance(

--- a/enderchest/test/test_place.py
+++ b/enderchest/test/test_place.py
@@ -572,6 +572,23 @@ class TestShulkerInstanceMatching:
             "Chest Boat",
         ]
 
+    def test_loader_matching_knows_how_to_interpret_fabric_like(self, tmp_path):
+        (tmp_path / "shulker.cfg").write_text("[modloader]\nFabric-Like\n")
+
+        loader_matching_shulker = ShulkerBox.from_cfg(tmp_path / "shulker.cfg")
+
+        instances = [
+            utils.instance("match_me", Path("foo"), modloader="Fabric Loader"),
+            utils.instance("dont-match-me", Path("blah"), modloader="Fabulous Loader"),
+            utils.instance("match me too", Path("bruh"), modloader="Quilt Loader"),
+        ]
+
+        assert [
+            instance.name
+            for instance in instances
+            if loader_matching_shulker.matches(instance)
+        ] == ["match_me", "match me too"]
+
     def test_loader_checks_multi_argument(self):
         loader_matching_shulker = ShulkerBox(
             0,

--- a/enderchest/test/testing_files/enderchest.cfg
+++ b/enderchest/test/testing_files/enderchest.cfg
@@ -22,7 +22,7 @@ groups = vanilla
 root = instances/bee/.minecraft
 minecraft_version = 1.18.2
 modloader = Forge
-groups = modded
+groups = Modded
 
 [Chest Boat]
 root = instances/chest-boat/.minecraft

--- a/enderchest/test/testing_files/enderchest.cfg
+++ b/enderchest/test/testing_files/enderchest.cfg
@@ -6,7 +6,7 @@ minecraft_version =
     1.20-pre1
     23w13a_or_b
     1.16.5-forge-36.2.39  ; this should be ignored
-tags =
+groups =
     vanilla  ; set by default
     latest-release
     latest-snapshot
@@ -16,16 +16,16 @@ tags =
 root = instances/axolotl/.minecraft
 minecraft_version = 1.17.1
 modloader =
-tags = vanilla
+groups = vanilla
 
 [bee]
 root = instances/bee/.minecraft
 minecraft_version = 1.18.2
 modloader = Forge
-tags = modded
+groups = modded
 
 [Chest Boat]
 root = instances/chest-boat/.minecraft
 minecraft_version = 1.19.0
 modloader = Fabric Loader
-tags = Vanilla Plus
+groups = Vanilla Plus

--- a/enderchest/test/utils.py
+++ b/enderchest/test/utils.py
@@ -447,11 +447,17 @@ def instance(
     root: Path,
     minecraft_versions: Iterable[str] | None = None,
     modloader: str | None = None,
+    groups: Iterable[str] | None = None,
     tags: Iterable[str] | None = None,
 ) -> InstanceSpec:
     """Shortcut constructor"""
     return InstanceSpec(
-        name, root, tuple(minecraft_versions or ()), modloader or "", tuple(tags or ())
+        name,
+        root,
+        tuple(minecraft_versions or ()),
+        modloader or "",
+        tuple(groups or ()),
+        tuple(tags or ()),
     )
 
 
@@ -462,5 +468,6 @@ def normalize_instance(mc: InstanceSpec) -> InstanceSpec:
         root=mc.root.expanduser().relative_to(mc.root.expanduser().parent.parent),
         modloader=normalize_modloader(mc.modloader)[0],
         minecraft_versions=tuple(sorted(mc.minecraft_versions)),
-        tags=tuple(sorted(tag.lower() for tag in mc.tags)),
+        groups_=tuple(sorted(group.lower() for group in mc.groups_)),
+        tags_=tuple(sorted(tag.lower() for tag in mc.tags_)),
     )


### PR DESCRIPTION
## Summary
<!--- One sentence summary of this PR. Can oftentimes just be a matter of linking
      to the issue number --->

Implements #54 by separating out "groups" from "tags," with both being used for matching, but only "grounds" getting overridden on an `enderchest gather minecrafts` refresh

## List of Changes
<!--- List out the changes introduced by this PR, permalinking
      (read: with commit hash) to the commit, file or section of code where
      that change was implemented --->

* Implements "instance merging," where two matching instances (meaning they point to the same instance folder) get their metadata combined, with:
  - the existing instance name getting kept
  - the non-group tags getting combined between the two
  - everything else taken from the new instance
* Adds some additional unrelated tests

## Tech Debt and Other Concerns
<!--- Use this section to call out anything in the code (including stuff you
      discovered outside of your contributions!) that you think may cause
      issues either now or further down the road. These will need to be spun
      off into issues before the PR is closed but shouldn't impede you opening
      the PR and starting the review process --->


<!--- Un-comment this section if this is still a work in progress. When doing
      so, please be sure to add (WIP), (Draft) or (DNM) in the PR title and
      open this PR as a draft

## To Do

--->


## Validation Performed
<!--- What did you do to ensure that this change is behaving as intended? This
should start with unit tests, but it's usually a good idea to try running
the code in a real setting. Include screenshots if you'd like, but make sure to
remove any personal information you won't want to share --->

- I ate my own dogfood and ran `enderchest gather minecrafts` against my own EnderChest setup. The diff was a little messy because it re-ordered the instances, but here's an example of before and after:

```diff
3,4c3,4
< last-modified = 2023-09-07
< generated-by-enderchest-version = manual
---
> last-modified = 2023-09-17 17:29:55.852538
> generated-by-enderchest-version = 0.1.2+49.gda649aa
9a10
> groups = Esha Ness
11d11
< 	Esha Ness
12a13,14
> 	Dev
> 	Esha Ness
15d16
< 	Dev
```

In other words,
- it added "Esha Ness" (the launcher group) to "groups," sorted the tags, and kept the original name even though I got a warning message:
```
Could not parse instance name from /main/minecraft/instances/RenderPearl/instance.cfg
```

## PR Type
<!--- Check all that apply --->
- [ ] This PR introduces a breaking change (will
  [require a bump in the minor version](https://semver.org/))
- [ ] The changes in this PR are high urgency and necessitate a hotfix or patch
  release (will require rebasing off of `release`)
- [ ] This is a release (staging) PR (maintainer use only)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.
      All bullets in this section are required to be checked off before the PR can
      be merged, but they don't need to be checked off before the PR is opened.
      If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] I have read [the contributor's guide](https://openbagtwo.github.io/EnderChest/dev/contrib/)
- [x] I have run `mkdocs serve` locally and ensured that all API docs and
  changes I have made to the static pages are rendering correctly, with all links
  working
- [x] All tech debt concerns have been resolved, documented as issues, or otherwise
  accepted
- [x] I agree to license my contribution to this project under
  [the GNU Public License v3](https://www.gnu.org/licenses/gpl-3.0.en.html)
  <!--- If you wish to use a different compatible license, please edit the above--->


<!--- Adapted from https://github.com/stevemao/github-issue-templates --->
