### PR TITLE
Fix issue with incorrect default value being set for place-after-open

### DIFF
--- a/enderchest/enderchest.py
+++ b/enderchest/enderchest.py
@@ -306,6 +306,7 @@ class EnderChest:
             )
             place_after_open = False
             ender_chest.write_to_cfg(config_file)
+            return cls.from_cfg(config_file)
         ender_chest.place_after_open = place_after_open
         ender_chest.offer_to_update_symlink_allowlist = (
             offer_to_update_symlink_allowlist
@@ -324,6 +325,7 @@ class EnderChest:
                 )
                 ender_chest.do_not_sync.insert(0, chest_cfg_exclusion)
                 ender_chest.write_to_cfg(config_file)
+                return cls.from_cfg(config_file)
         return ender_chest
 
     def write_to_cfg(self, config_file: Path | None = None) -> str:

--- a/enderchest/enderchest.py
+++ b/enderchest/enderchest.py
@@ -104,7 +104,7 @@ class EnderChest:
                 self._uri = urlparse(uri.absolute().as_uri())
             else:
                 self._uri = urlparse(uri)
-        except AttributeError as parse_problem:
+        except AttributeError as parse_problem:  # pragma: no cover
             raise ValueError(f"{uri} is not a valid URI") from parse_problem
 
         if not self._uri.netloc:
@@ -179,8 +179,8 @@ class EnderChest:
             counter += 1
             name = f"{instance.name}.{counter}"
 
-        GATHER_LOGGER.debug(f"Registering instance {instance.name} at {instance.root}")
-        self._instances.append(instance)
+        GATHER_LOGGER.debug(f"Registering instance {name} at {instance.root}")
+        self._instances.append(instance._replace(name=name))
         return self._instances[-1]
 
     @property

--- a/enderchest/enderchest.py
+++ b/enderchest/enderchest.py
@@ -209,11 +209,11 @@ class EnderChest:
         try:
             remote = remote if isinstance(remote, ParseResult) else urlparse(remote)
             alias = alias or remote.hostname
-            if not alias:
+            if not alias:  # pragma: no cover
                 raise AttributeError(f"{remote.geturl()} has no hostname")
             GATHER_LOGGER.debug("Registering remote %s (%s)", remote.geturl(), alias)
             self._remotes[alias] = remote
-        except AttributeError as parse_problem:
+        except AttributeError as parse_problem:  # pragma: no cover
             raise ValueError(f"{remote} is not a valid URI") from parse_problem
 
     @classmethod

--- a/enderchest/enderchest.py
+++ b/enderchest/enderchest.py
@@ -237,6 +237,7 @@ class EnderChest:
         FileNotFoundError
             If there is no config file at the specified location
         """
+        GATHER_LOGGER.debug("Reading config file from %s", config_file)
         config = cfg.read_cfg(config_file)
 
         # All I'm gonna say is that Windows pathing is the worst
@@ -378,6 +379,7 @@ class EnderChest:
         )
 
         if config_file:
+            CRAFT_LOGGER.debug("Writing configuration file to %s", config_file)
             config_file.write_text(config)
         return config
 

--- a/enderchest/test/test_config.py
+++ b/enderchest/test/test_config.py
@@ -104,7 +104,7 @@ class TestConfigWriting:
         (tmp_path / "EnderChest").mkdir()
 
         original_ender_chest = EnderChest(
-            urlparse(tmp_path.absolute().as_uri()),
+            tmp_path,
             name="tester",
             instances=(
                 InstanceSpec(

--- a/enderchest/test/test_config.py
+++ b/enderchest/test/test_config.py
@@ -177,3 +177,39 @@ class TestConfigParsing:
         )
         with pytest.raises(ValueError, match="is not a valid URI"):
             _ = EnderChest.from_cfg(config_file)
+
+    def test_sync_confirm_wait_prompt_is_read_as_true(self, tmp_path):
+        config_file = tmp_path / "enderchest.cfg"
+        config_file.write_text(
+            "[properties]"
+            "\nname=tester"
+            "\nplace-after-open=no"
+            "\nsync-confirmation-time=prompt"
+        )
+        assert EnderChest.from_cfg(config_file).sync_confirm_wait is True
+
+    def test_raise_on_invalid_sync_confirm_wait(self, tmp_path):
+        config_file = tmp_path / "enderchest.cfg"
+        config_file.write_text(
+            "[properties]"
+            "\nname=tester"
+            "\nplace-after-open=no"
+            "\nsync-confirmation-time=sounds like a good idea"
+        )
+        with pytest.raises(ValueError, match="Invalid value for"):
+            _ = EnderChest.from_cfg(config_file).sync_confirm_wait
+
+    def test_raise_when_remote_has_no_alias(self, tmp_path):
+        config_file = tmp_path / "enderchest.cfg"
+        config_file.write_text(
+            "[properties]"
+            "\nname=tester"
+            "\nplace-after-open=no"
+            "\n\n[remotes]"
+            "\n/some/where"
+        )
+
+        with pytest.raises(
+            ValueError, match="All remotes must have an alias specified"
+        ):
+            _ = EnderChest.from_cfg(config_file)

--- a/enderchest/test/test_gather.py
+++ b/enderchest/test/test_gather.py
@@ -303,7 +303,7 @@ class TestGatherInstances:
     def test_updating_an_instance_does_not_overwrite_tags(self, minecraft_root, home):
         enderchest = gather.load_ender_chest(minecraft_root)
 
-        expected: dict[Path, tuple[str, ...]] = {}
+        expected: dict[str, tuple[str, ...]] = {}
         for idx, instance in enumerate(enderchest._instances):
             tags = tuple((str(num) for num in range(idx + 1)))
             expected[instance.name] = tuple(sorted(tags + instance.groups_))


### PR DESCRIPTION
## Summary
<!--- One sentence summary of this PR. Can oftentimes just be a matter of linking
      to the issue number --->

Fixes #91

## List of Changes
<!--- List out the changes introduced by this PR, permalinking
      (read: with commit hash) to the commit, file or section of code where
      that change was implemented --->

* Changes the way that configs self-correct to ensure that the self-corrected settings get written to file and then the re-written config is reread
* Adds some additional config-parsing tests
* Fixes a previously un-caught bug where instances that shared a name would conflict

## Tech Debt and Other Concerns
<!--- Use this section to call out anything in the code (including stuff you
      discovered outside of your contributions!) that you think may cause
      issues either now or further down the road. These will need to be spun
      off into issues before the PR is closed but shouldn't impede you opening
      the PR and starting the review process --->


<!--- Un-comment this section if this is still a work in progress. When doing
      so, please be sure to add (WIP), (Draft) or (DNM) in the PR title and
      open this PR as a draft

## To Do

--->


## Validation Performed
<!--- What did you do to ensure that this change is behaving as intended? This
should start with unit tests, but it's usually a good idea to try running
the code in a real setting. Include screenshots if you'd like, but make sure to
remove any personal information you won't want to share --->

Tested this fix on my own instance by deleting the `place-after-open` line in my config, then running `open`.
- [x] I got the autocorrecting message
- [x] I didn't get a bunch of place messages after the sync was finished
- [x] The value of the new config line was `place-after-open = False` as expected 

## PR Type
<!--- Check all that apply --->
- [ ] This PR introduces a breaking change (will
  [require a bump in the minor version](https://semver.org/))
- [x] The changes in this PR are high urgency and necessitate a hotfix or patch
  release ~~(will require rebasing off of `release`)~~
- [ ] This is a release (staging) PR (maintainer use only)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.
      All bullets in this section are required to be checked off before the PR can
      be merged, but they don't need to be checked off before the PR is opened.
      If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] I have read [the contributor's guide](https://openbagtwo.github.io/EnderChest/dev/contrib/)
- [x] I have run `mkdocs serve` locally and ensured that all API docs and
  changes I have made to the static pages are rendering correctly, with all links
  working
- [x] All tech debt concerns have been resolved, documented as issues, or otherwise
  accepted
- [x] I agree to license my contribution to this project under
  [the GNU Public License v3](https://www.gnu.org/licenses/gpl-3.0.en.html)
  <!--- If you wish to use a different compatible license, please edit the above--->


<!--- Adapted from https://github.com/stevemao/github-issue-templates --->
