### PR TITLE
Add "retry" option to place prompt

### DIFF
--- a/enderchest/place.py
+++ b/enderchest/place.py
@@ -68,7 +68,7 @@ def place_ender_chest(
       an outdated symlink if the fully resolved target of a link falls outside
       the EnderChest folder.
     """
-    if rollback is not False:  # pragma: no-cover
+    if rollback is not False:  # pragma: no cover
         raise NotImplementedError("Rollbacks are not currently supported")
 
     try:

--- a/enderchest/test/conftest.py
+++ b/enderchest/test/conftest.py
@@ -1,6 +1,7 @@
 """Useful setup / teardown fixtures"""
 from importlib.resources import as_file
 from pathlib import Path
+from typing import Generator
 
 import pytest
 
@@ -17,7 +18,7 @@ def use_local_ssh(request):
 
 
 @pytest.fixture
-def file_system(tmp_path):
+def file_system(tmp_path) -> Generator[tuple[Path, Path], None, None]:
     """Create a testing file system and throw a bunch of random files across
     it.
 

--- a/enderchest/test/test_cli.py
+++ b/enderchest/test/test_cli.py
@@ -2,6 +2,7 @@
 import logging
 import os
 from pathlib import Path
+from typing import Generator
 
 import pytest
 
@@ -205,7 +206,7 @@ class TestPlace(ActionTestSuite):
     action = "place"
 
     @pytest.fixture
-    def place_log(self, monkeypatch):
+    def place_log(self, monkeypatch) -> Generator[list[tuple[Path, dict]], None, None]:
         place_log: list[tuple[Path, dict]] = []
 
         def mock_place(path, **kwargs):
@@ -394,10 +395,10 @@ class TestOpen:
     action = "open"
     op = "pull"
 
-    def test_op_is_routed_successfully(self, monkeypatch):
+    def test_op_is_routed_successfully(self, monkeypatch) -> None:
         sync_log: list[tuple[str, str, dict]] = []
 
-        def mock_sync(root, op, **kwargs):
+        def mock_sync(root, op, **kwargs) -> None:
             sync_log.append((root, op, kwargs))
 
         monkeypatch.setattr(remote, "sync_with_remotes", mock_sync)
@@ -422,10 +423,10 @@ class TestOpen:
     )
     def test_verbosity_modifier_is_passed_to_op(
         self, monkeypatch, verbosity_flag, expected_verbosity
-    ):
+    ) -> None:
         sync_log: list[tuple[str, str, dict]] = []
 
-        def mock_sync(root, op, **kwargs):
+        def mock_sync(root, op, **kwargs) -> None:
             sync_log.append((root, op, kwargs))
 
         monkeypatch.setattr(remote, "sync_with_remotes", mock_sync)
@@ -438,10 +439,10 @@ class TestOpen:
         assert len(sync_log) == 1
         assert sync_log[0][2]["verbosity"] == expected_verbosity
 
-    def test_dry_run_is_false_by_default(self, monkeypatch):
+    def test_dry_run_is_false_by_default(self, monkeypatch) -> None:
         sync_log: list[tuple[str, str, dict]] = []
 
-        def mock_sync(root, op, **kwargs):
+        def mock_sync(root, op, **kwargs) -> None:
             sync_log.append((root, op, kwargs))
 
         monkeypatch.setattr(remote, "sync_with_remotes", mock_sync)
@@ -452,10 +453,10 @@ class TestOpen:
         assert len(sync_log) == 1
         assert sync_log[0][2]["dry_run"] is False
 
-    def test_passing_a_bunch_of_args(self, monkeypatch):
+    def test_passing_a_bunch_of_args(self, monkeypatch) -> None:
         sync_log: list[tuple[str, str, dict]] = []
 
-        def mock_sync(root, op, **kwargs):
+        def mock_sync(root, op, **kwargs) -> None:
             sync_log.append((root, op, kwargs))
 
         monkeypatch.setattr(remote, "sync_with_remotes", mock_sync)

--- a/enderchest/test/test_craft.py
+++ b/enderchest/test/test_craft.py
@@ -37,7 +37,9 @@ class TestEnderChestCrafting:
 
         craft.craft_ender_chest(minecraft_root / "trunk")
 
-    def test_no_kwargs_routes_to_the_interactive_prompter(self, monkeypatch, tmpdir):
+    def test_no_kwargs_routes_to_the_interactive_prompter(
+        self, monkeypatch, tmpdir
+    ) -> None:
         prompt_log: list[Path] = []
 
         def mock_prompt(root) -> Any:
@@ -72,7 +74,7 @@ class TestEnderChestCrafting:
         argument,
         value,
         minecraft_root,
-    ):
+    ) -> None:
         def mock_prompt(root) -> Any:
             raise AssertionError("I was not to be called.")
 
@@ -247,7 +249,7 @@ class TestShulkerBoxCrafting:
             == 0
         )
 
-    def test_no_kwargs_routes_to_the_interactive_prompter(self, monkeypatch):
+    def test_no_kwargs_routes_to_the_interactive_prompter(self, monkeypatch) -> None:
         prompt_log: list[tuple[Path, str]] = []
 
         def mock_prompt(root, name) -> Any:
@@ -280,7 +282,7 @@ class TestShulkerBoxCrafting:
     )
     def test_any_kwarg_avoids_the_interactive_prompter(
         self, monkeypatch, argument, value
-    ):
+    ) -> None:
         def mock_prompt(root) -> Any:
             raise AssertionError("I was not to be called.")
 

--- a/enderchest/test/test_gather.py
+++ b/enderchest/test/test_gather.py
@@ -300,7 +300,9 @@ class TestGatherInstances:
             ]
         )
 
-    def test_updating_an_instance_does_not_overwrite_tags(self, minecraft_root, home):
+    def test_updating_an_instance_does_not_overwrite_tags(
+        self, minecraft_root, home
+    ) -> None:
         enderchest = gather.load_ender_chest(minecraft_root)
 
         expected: dict[str, tuple[str, ...]] = {}

--- a/enderchest/test/test_place.py
+++ b/enderchest/test/test_place.py
@@ -27,7 +27,7 @@ class TestRglob:
 
         assert rglob == sorted(place._rglob(minecraft_root / "workspace", 0))
 
-    def test_max_depth_of_two_returns_subdirectories(self, minecraft_root):
+    def test_max_depth_of_two_returns_subdirectories(self, minecraft_root) -> None:
         instances_folder = minecraft_root / "instances"
         expected: list[Path] = [instances_folder / "instgroups.json"]
         for instance in utils.TESTING_INSTANCES[1:]:
@@ -817,7 +817,7 @@ class TestMultiShulkerPlacing:
             minecraft_root / "instances" / "chest-boat" / ".minecraft" / "options.txt"
         ).exists()
 
-    def test_prompt_and_retry(self, home, minecraft_root, caplog, monkeypatch):
+    def test_prompt_and_retry(self, home, minecraft_root, caplog, monkeypatch) -> None:
         conflict_file_path = home / ".minecraft" / "options.txt"
         safe_keeping = minecraft_root / "options.txt.bkp"
 

--- a/enderchest/test/test_place.py
+++ b/enderchest/test/test_place.py
@@ -831,11 +831,7 @@ class TestMultiShulkerPlacing:
 
         # note: there's actually no guarantee that this link didn't generate
         #       before the failure...
-        assert (
-            home / ".minecraft" / "mods" / "FoxNap.jar"
-        ).readlink() == fs.shulker_box_root(
-            minecraft_root, "1.19"
-        ) / "mods" / "FoxNap.jar"
+        assert (home / ".minecraft" / "mods" / "FoxNap.jar").is_symlink()  # and exists
 
     @pytest.mark.parametrize("prompt", (False, True), ids=["", "prompted"])
     def test_skip_match(
@@ -954,9 +950,7 @@ class TestMultiShulkerPlacing:
             error_idx = errors[0]
             assert "options.txt already exists" in caplog.records[error_idx].msg
 
-            assert conflict_file_path.readlink() == (
-                fs.shulker_box_root(minecraft_root, "1.19") / "options.txt"
-            )
+            assert conflict_file_path.is_symlink()
         finally:
             if safe_keeping.exists():
                 conflict_file_path.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
<!--- One sentence summary of this PR. Can oftentimes just be a matter of linking
      to the issue number --->

Partially implements #61 by adding the option to retry a `place` operation in the event of a conflict

## List of Changes
<!--- List out the changes introduced by this PR, permalinking
      (read: with commit hash) to the commit, file or section of code where
      that change was implemented --->

* When a conflict occurs during the `place` command using the `prompt` error-handling method, the prompt will now read:
   ```
   Error linking ...
   ==> How would you like to proceed?
   ==> [Q]uit; [R]etry; [C]ontinue; skip linking the rest of this:
   ==> [I]nstance, [S]hulker box, shulker/instance [M]atch?
   ==> [R]
   ```
   (note that retry is now the default), and the failed linking operation will be retired if so selected  
* This PR also introduces a bunch of place tests (mostly around the various error handling methods) that bring the test coverage up to :100: :tada: :tada: :tada:

## Tech Debt and Other Concerns
<!--- Use this section to call out anything in the code (including stuff you
      discovered outside of your contributions!) that you think may cause
      issues either now or further down the road. These will need to be spun
      off into issues before the PR is closed but shouldn't impede you opening
      the PR and starting the review process --->


<!--- Un-comment this section if this is still a work in progress. When doing
      so, please be sure to add (WIP), (Draft) or (DNM) in the PR title and
      open this PR as a draft

## To Do

--->


## Validation Performed
<!--- What did you do to ensure that this change is behaving as intended? This
should start with unit tests, but it's usually a good idea to try running
the code in a real setting. Include screenshots if you'd like, but make sure to
remove any personal information you won't want to share --->
Dogfooded this by intentionally introducing a conflict, trying to `place`, then when I got the above prompt, removing the conflict and selecting "retry." The `place` then completed successfully.

## PR Type
<!--- Check all that apply --->
- [ ] This PR introduces a breaking change (will
  [require a bump in the minor version](https://semver.org/))
- [ ] The changes in this PR are high urgency and necessitate a hotfix or patch
  release (will require rebasing off of `release`)
- [ ] This is a release (staging) PR (maintainer use only)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.
      All bullets in this section are required to be checked off before the PR can
      be merged, but they don't need to be checked off before the PR is opened.
      If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] I have read [the contributor's guide](https://openbagtwo.github.io/EnderChest/dev/contrib/)
- [x] I have run `mkdocs serve` locally and ensured that all API docs and
  changes I have made to the static pages are rendering correctly, with all links
  working
- [x] All tech debt concerns have been resolved, documented as issues, or otherwise
  accepted
- [x] I agree to license my contribution to this project under
  [the GNU Public License v3](https://www.gnu.org/licenses/gpl-3.0.en.html)
  <!--- If you wish to use a different compatible license, please edit the above--->


<!--- Adapted from https://github.com/stevemao/github-issue-templates --->


## Notes

- The rest of #61 will be spun off for a future release.
- This being the last functionality change of [the milestone](https://github.com/OpenBagTwo/EnderChest/milestone/5), the next step will be to start a release/staging PR where the remaining two stories (around documentation) will be addressed.