### PR TITLE
Fix SFTP mtime comparsion

### DIFF
--- a/docs/contrib.md
+++ b/docs/contrib.md
@@ -154,11 +154,11 @@ The current procedure to regenerate that cache is:
 1. Un-comment [this unit test](https://github.com/OpenBagTwo/EnderChest/blob/853bdbac76124fb9e6d4a754f4dd73c48e66d829/enderchest/test/test_sync.py#L542-L545)
 1. Run
    ```bash
-   pytest enderchest/tests/test_sync.py::TestSFTPSync::test_generate_lstat_cache --use-local-ssh
+   pytest enderchest/test/test_sync.py::TestSFTPSync::test_generate_lstat_cache --use-local-ssh
    ```
 1. Re-comment-out that test, then make sure the cache is working by running
    ```bash
-   pytest -vvx enderchest/tests/test_sync.py::TestSFTPSync
+   pytest -vvx enderchest/test/test_sync.py::TestSFTPSync
    ```
 1. If all tests pass when using the cache, then make sure to `git add` the
    regenerated testing file and include it in your next commit

--- a/enderchest/sync/utils.py
+++ b/enderchest/sync/utils.py
@@ -134,9 +134,9 @@ def is_identical(object_one: _StatLike, object_two: _StatLike) -> bool:
 
     if stat.S_ISREG(object_one.st_mode or 0):
         # these comparisons should only be run on files
-        if object_one.st_size != object_two.st_size:
+        if int(object_one.st_size or 0) != int(object_two.st_size or 0):
             return False
-        if object_one.st_mtime != object_two.st_mtime:
+        if int(object_one.st_mtime or 0) != int(object_two.st_mtime or 0):
             return False
     return True
 

--- a/enderchest/test/mock_paramiko.py
+++ b/enderchest/test/mock_paramiko.py
@@ -47,6 +47,7 @@ class MockSFTP:
         self.lstat_cache: dict[Path, CachedStat] = {
             root
             / stat["filename"]: CachedStat(**stat)._replace(
+                st_size=(root / stat["filename"]).stat().st_size,
                 st_mtime=(root / stat["filename"]).stat().st_mtime,
                 st_atime=(root / stat["filename"]).stat().st_atime,
             )

--- a/enderchest/test/test_cli.py
+++ b/enderchest/test/test_cli.py
@@ -61,6 +61,7 @@ class ActionTestSuite:
 
     def test_default_root_is_cwd(self, monkeypatch):
         monkeypatch.setattr(os, "getcwd", lambda: "~~dummy~~")
+        monkeypatch.delenv("MINECRAFT_ROOT", raising=False)
         _, root, _, _ = cli.parse_args(
             ["enderchest", *self.action.split(), *self.required_args]
         )
@@ -299,7 +300,10 @@ class TestGather(ActionTestSuite):
         _ = capsys.readouterr()  # suppress outputs
 
     @pytest.mark.parametrize("with_root", (False, True), ids=("no_root", "with-root"))
-    def test_single_arg_interpreted_as_search_path(self, with_root, capsys):
+    def test_single_arg_interpreted_as_search_path(
+        self, with_root, capsys, monkeypatch
+    ):
+        monkeypatch.delenv("MINECRAFT_ROOT", raising=False)
         more_args = ("--root", ".") if with_root else ()
 
         _, root, _, options = cli.parse_args(
@@ -344,7 +348,8 @@ class TestGatherRemote(ActionTestSuite):
         _ = capsys.readouterr()  # suppress outputs
 
     @pytest.mark.parametrize("with_root", (False, True), ids=("no_root", "with-root"))
-    def test_single_arg_interpreted_as_remote(self, with_root):
+    def test_single_arg_interpreted_as_remote(self, with_root, monkeypatch):
+        monkeypatch.delenv("MINECRAFT_ROOT", raising=False)
         more_args = ("--root", ".") if with_root else ()
 
         _, root, _, options = cli.parse_args(

--- a/enderchest/test/test_sync.py
+++ b/enderchest/test/test_sync.py
@@ -843,26 +843,6 @@ class TestSFTPSync(TestFileSync):
             )
             monkeypatch.setattr(sftp, "rglob", mock_paramiko.mock_rglob)
 
-    @pytest.fixture(autouse=True)
-    def patch_mtime_comparison(self, monkeypatch, use_local_ssh) -> None:
-        if not use_local_ssh:
-            inner_identical_check = sync_utils.is_identical
-
-            def patched_is_identical(
-                object_one: sync_utils._StatLike, object_two: sync_utils._StatLike
-            ) -> bool:
-                if isinstance(object_one, mock_paramiko.CachedStat):
-                    object_one = object_one._replace(
-                        st_mtime=object_two.st_mtime  # type: ignore[arg-type]
-                    )
-                elif isinstance(object_two, mock_paramiko.CachedStat):
-                    object_two = object_two._replace(
-                        st_mtime=object_one.st_mtime  # type: ignore[arg-type]
-                    )
-                return inner_identical_check(object_one, object_two)
-
-            monkeypatch.setattr(sync_utils, "is_identical", patched_is_identical)
-
     @pytest.fixture(autouse=False)
     def generate_lstat_cache(self, remote):
         from enderchest.sync import sftp

--- a/enderchest/test/test_sync_utils.py
+++ b/enderchest/test/test_sync_utils.py
@@ -91,7 +91,7 @@ class TestIsIdentical:
         one.write_text("I'm the original")
         two = tmp_path / "two"
         shutil.copy(one, two)
-        time.sleep(0.01)
+        time.sleep(1)  # ugh
         two.write_text("I'm the original")
 
         # meta-test that the file contents are identical
@@ -103,7 +103,7 @@ class TestIsIdentical:
         one = tmp_path / "one"
         one.mkdir(parents=True)
         two = tmp_path / "two"
-        time.sleep(0.01)
+        time.sleep(1)  # ugh
         two.mkdir()
         assert sync_utils.is_identical(one.stat(), two.stat())
 

--- a/enderchest/test/testing_files/lstat_cache.json
+++ b/enderchest/test/testing_files/lstat_cache.json
@@ -2,109 +2,121 @@
     {
         "filename": "enderchest.cfg",
         "st_mode": 33188,
-        "st_size": 989,
-        "st_mtime": 1694612231
+        "st_size": 1058,
+        "st_mtime": 1696352772
     },
     {
         "filename": "steamdeck",
         "st_mode": 16877,
         "st_size": 60,
-        "st_mtime": 1694612231
+        "st_mtime": 1696352772
     },
     {
         "filename": "steamdeck/shulkerbox.cfg",
         "st_mode": 33188,
         "st_size": 73,
-        "st_mtime": 1694612231
+        "st_mtime": 1696352772
     },
     {
         "filename": "optifine",
         "st_mode": 16877,
         "st_size": 80,
-        "st_mtime": 1694612231
+        "st_mtime": 1696352772
     },
     {
         "filename": "optifine/mods",
         "st_mode": 16877,
         "st_size": 80,
-        "st_mtime": 1694612231
+        "st_mtime": 1696352772
     },
     {
         "filename": "optifine/mods/optifine.jar",
         "st_mode": 33188,
         "st_size": 9,
-        "st_mtime": 1694612231
+        "st_mtime": 1696352772
     },
     {
         "filename": "optifine/mods/BME.jar",
         "st_mode": 41471,
         "st_size": 124,
-        "st_mtime": 1694612231
+        "st_mtime": 1696352772
     },
     {
         "filename": "optifine/shulkerbox.cfg",
         "st_mode": 33188,
         "st_size": 173,
-        "st_mtime": 1694612231
+        "st_mtime": 1696352772
     },
     {
         "filename": "vanilla",
         "st_mode": 16877,
         "st_size": 80,
-        "st_mtime": 1694612231
+        "st_mtime": 1696352772
     },
     {
         "filename": "vanilla/conflict",
         "st_mode": 16877,
         "st_size": 60,
-        "st_mtime": 1694612231
+        "st_mtime": 1696352772
     },
     {
         "filename": "vanilla/conflict/diamond.png",
         "st_mode": 33188,
         "st_size": 10,
-        "st_mtime": 1694612231
+        "st_mtime": 1696352772
     },
     {
         "filename": "vanilla/shulkerbox.cfg",
         "st_mode": 33188,
         "st_size": 126,
-        "st_mtime": 1694612231
+        "st_mtime": 1696352772
     },
     {
         "filename": "1.19",
         "st_mode": 16877,
-        "st_size": 100,
-        "st_mtime": 1694612231
+        "st_size": 120,
+        "st_mtime": 1696352772
+    },
+    {
+        "filename": "1.19/resourcepacks",
+        "st_mode": 16877,
+        "st_size": 60,
+        "st_mtime": 1696352772
+    },
+    {
+        "filename": "1.19/resourcepacks/TEAVSRP_lite.zip",
+        "st_mode": 33188,
+        "st_size": 18,
+        "st_mtime": 1696352772
     },
     {
         "filename": "1.19/.bobby",
         "st_mode": 16877,
         "st_size": 60,
-        "st_mtime": 1694612231
+        "st_mtime": 1696352772
     },
     {
         "filename": "1.19/.bobby/chunk",
         "st_mode": 33188,
         "st_size": 7,
-        "st_mtime": 1694612231
+        "st_mtime": 1696352772
     },
     {
         "filename": "1.19/saves",
         "st_mode": 16877,
         "st_size": 60,
-        "st_mtime": 1694612231
+        "st_mtime": 1696352772
     },
     {
         "filename": "1.19/saves/olam",
         "st_mode": 41471,
         "st_size": 98,
-        "st_mtime": 1694612231
+        "st_mtime": 1696352772
     },
     {
         "filename": "1.19/shulkerbox.cfg",
         "st_mode": 33188,
         "st_size": 139,
-        "st_mtime": 1694612231
+        "st_mtime": 1696352772
     }
 ]

--- a/enderchest/test/testing_files/lstat_cache.json
+++ b/enderchest/test/testing_files/lstat_cache.json
@@ -2,121 +2,141 @@
     {
         "filename": "enderchest.cfg",
         "st_mode": 33188,
-        "st_size": 1058,
-        "st_mtime": 1696352772
+        "st_size": 1059,
+        "st_atime": 1696358575,
+        "st_mtime": 1696358575
     },
     {
         "filename": "steamdeck",
         "st_mode": 16877,
         "st_size": 60,
-        "st_mtime": 1696352772
+        "st_atime": 1696358575,
+        "st_mtime": 1696358575
     },
     {
         "filename": "steamdeck/shulkerbox.cfg",
         "st_mode": 33188,
         "st_size": 73,
-        "st_mtime": 1696352772
+        "st_atime": 1696358575,
+        "st_mtime": 1696358575
     },
     {
         "filename": "optifine",
         "st_mode": 16877,
         "st_size": 80,
-        "st_mtime": 1696352772
+        "st_atime": 1696358575,
+        "st_mtime": 1696358575
     },
     {
         "filename": "optifine/mods",
         "st_mode": 16877,
         "st_size": 80,
-        "st_mtime": 1696352772
+        "st_atime": 1696358575,
+        "st_mtime": 1696358575
     },
     {
         "filename": "optifine/mods/optifine.jar",
         "st_mode": 33188,
         "st_size": 9,
-        "st_mtime": 1696352772
+        "st_atime": 1696358575,
+        "st_mtime": 1696358575
     },
     {
         "filename": "optifine/mods/BME.jar",
         "st_mode": 41471,
         "st_size": 124,
-        "st_mtime": 1696352772
+        "st_atime": 1696358575,
+        "st_mtime": 1696358575
     },
     {
         "filename": "optifine/shulkerbox.cfg",
         "st_mode": 33188,
         "st_size": 173,
-        "st_mtime": 1696352772
+        "st_atime": 1696358575,
+        "st_mtime": 1696358575
     },
     {
         "filename": "vanilla",
         "st_mode": 16877,
         "st_size": 80,
-        "st_mtime": 1696352772
+        "st_atime": 1696358575,
+        "st_mtime": 1696358575
     },
     {
         "filename": "vanilla/conflict",
         "st_mode": 16877,
         "st_size": 60,
-        "st_mtime": 1696352772
+        "st_atime": 1696358575,
+        "st_mtime": 1696358575
     },
     {
         "filename": "vanilla/conflict/diamond.png",
         "st_mode": 33188,
         "st_size": 10,
-        "st_mtime": 1696352772
+        "st_atime": 1696358575,
+        "st_mtime": 1696358575
     },
     {
         "filename": "vanilla/shulkerbox.cfg",
         "st_mode": 33188,
         "st_size": 126,
-        "st_mtime": 1696352772
+        "st_atime": 1696358575,
+        "st_mtime": 1696358575
     },
     {
         "filename": "1.19",
         "st_mode": 16877,
         "st_size": 120,
-        "st_mtime": 1696352772
+        "st_atime": 1696358575,
+        "st_mtime": 1696358575
     },
     {
         "filename": "1.19/resourcepacks",
         "st_mode": 16877,
         "st_size": 60,
-        "st_mtime": 1696352772
+        "st_atime": 1696358575,
+        "st_mtime": 1696358575
     },
     {
         "filename": "1.19/resourcepacks/TEAVSRP_lite.zip",
         "st_mode": 33188,
         "st_size": 18,
-        "st_mtime": 1696352772
+        "st_atime": 1696358575,
+        "st_mtime": 1696358575
     },
     {
         "filename": "1.19/.bobby",
         "st_mode": 16877,
         "st_size": 60,
-        "st_mtime": 1696352772
+        "st_atime": 1696358575,
+        "st_mtime": 1696358575
     },
     {
         "filename": "1.19/.bobby/chunk",
         "st_mode": 33188,
         "st_size": 7,
-        "st_mtime": 1696352772
+        "st_atime": 1696358575,
+        "st_mtime": 1696358575
     },
     {
         "filename": "1.19/saves",
         "st_mode": 16877,
         "st_size": 60,
-        "st_mtime": 1696352772
+        "st_atime": 1696358575,
+        "st_mtime": 1696358575
     },
     {
         "filename": "1.19/saves/olam",
         "st_mode": 41471,
         "st_size": 98,
-        "st_mtime": 1696352772
+        "st_atime": 1696358575,
+        "st_mtime": 1696358575
     },
     {
         "filename": "1.19/shulkerbox.cfg",
         "st_mode": 33188,
         "st_size": 139,
-        "st_mtime": 1696352772
+        "st_atime": 1696358575,
+        "st_mtime": 1696358575
     }
 ]


### PR DESCRIPTION
## Summary
<!--- One sentence summary of this PR. Can oftentimes just be a matter of linking
      to the issue number --->

Fixes #98

## List of Changes
<!--- List out the changes introduced by this PR, permalinking
      (read: with commit hash) to the commit, file or section of code where
      that change was implemented --->

* `is_identical` modification time comparison now truncates to the integer value (SFTPAttributes are only down to the second, looks like)
* there's now an explicit test ensuring that identical files are not synced
  * the lstat cache has been updated for the new testing file
* related to the above: fixed a typo in the lstat cache regeneration instructions

## Tech Debt and Other Concerns
<!--- Use this section to call out anything in the code (including stuff you
      discovered outside of your contributions!) that you think may cause
      issues either now or further down the road. These will need to be spun
      off into issues before the PR is closed but shouldn't impede you opening
      the PR and starting the review process --->


<!--- Un-comment this section if this is still a work in progress. When doing
      so, please be sure to add (WIP), (Draft) or (DNM) in the PR title and
      open this PR as a draft

## To Do

--->


## Validation Performed
<!--- What did you do to ensure that this change is behaving as intended? This
should start with unit tests, but it's usually a good idea to try running
the code in a real setting. Include screenshots if you'd like, but make sure to
remove any personal information you won't want to share --->
- [x] I have checked out this version of EnderChest on the Windows machine where I reported this error and have confirmed that this fix solves the issue

## PR Type
<!--- Check all that apply --->
- [ ] This PR introduces a breaking change (will
  [require a bump in the minor version](https://semver.org/))
- [ ] The changes in this PR are high urgency and necessitate a hotfix or patch
  release (will require rebasing off of `release`)
- [ ] This is a release (staging) PR (maintainer use only)

That said, this _is_ targeting the current staging branch.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.
      All bullets in this section are required to be checked off before the PR can
      be merged, but they don't need to be checked off before the PR is opened.
      If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] I have read [the contributor's guide](https://openbagtwo.github.io/EnderChest/dev/contrib/)
- [x] I have run `mkdocs serve` locally and ensured that all API docs and
  changes I have made to the static pages are rendering correctly, with all links
  working
- [x] All tech debt concerns have been resolved, documented as issues, or otherwise
  accepted
- [x] I agree to license my contribution to this project under
  [the GNU Public License v3](https://www.gnu.org/licenses/gpl-3.0.en.html)
  <!--- If you wish to use a different compatible license, please edit the above--->


<!--- Adapted from https://github.com/stevemao/github-issue-templates --->
