### PR TITLE
Combine arguments when multiple --exclude flags are passed

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -44,6 +44,7 @@ jobs:
         EOF
         cat ~/.ssh/id_ed25519.pub > ~/.ssh/authorized_keys
         chmod -R 700 ~/.ssh
+        echo "SSH configured for local passwordless authentication"
         ssh -o 'StrictHostKeyChecking no' $USER@$HOSTNAME "echo It works"
     - name: Install Rsync
       if: matrix.os == 'macos-latest'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -44,8 +44,10 @@ jobs:
         EOF
         cat ~/.ssh/id_ed25519.pub > ~/.ssh/authorized_keys
         chmod -R 700 ~/.ssh
-        echo "SSH configured for local passwordless authentication"
-        ssh -o 'StrictHostKeyChecking no' $USER@$HOSTNAME "echo It works"
+    - name: Verify Local SSH
+      if: matrix.os != 'windows-latest'
+      run: |
+        ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 -o BatchMode=yes $USER@$HOSTNAME "echo It works"
     - name: Install Rsync
       if: matrix.os == 'macos-latest'
       run: brew install rsync

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Verify Local SSH
       if: matrix.os != 'windows-latest'
       run: |
-        ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 -o BatchMode=yes $USER@$HOSTNAME "echo It works"
+        ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 -o BatchMode=yes $USER@localhost "echo It works"
     - name: Install Rsync
       if: matrix.os == 'macos-latest'
       run: brew install rsync

--- a/enderchest/cli.py
+++ b/enderchest/cli.py
@@ -550,6 +550,7 @@ def generate_parsers() -> tuple[ArgumentParser, dict[str, ArgumentParser]]:
         sync_parser.add_argument(
             "--exclude",
             "-e",
+            action="extend",
             nargs="+",
             help="Provide any file patterns you would like to skip syncing",
         )


### PR DESCRIPTION
## Summary
<!--- One sentence summary of this PR. Can oftentimes just be a matter of linking
      to the issue number --->

Fixes #103

## List of Changes
<!--- List out the changes introduced by this PR, permalinking
      (read: with commit hash) to the commit, file or section of code where
      that change was implemented --->

* Adds a test to ensure that multiple `--exclude` flags are combined in the CLI...
* ... and then actually implements that behavior
* Also ended up fixing #110 via de6af69bf6178c68f3c41fdcda025d8545080db0

## Tech Debt and Other Concerns
<!--- Use this section to call out anything in the code (including stuff you
      discovered outside of your contributions!) that you think may cause
      issues either now or further down the road. These will need to be spun
      off into issues before the PR is closed but shouldn't impede you opening
      the PR and starting the review process --->

Discovered #108 while testing.


<!--- Un-comment this section if this is still a work in progress. When doing
      so, please be sure to add (WIP), (Draft) or (DNM) in the PR title and
      open this PR as a draft

## To Do

--->


## Validation Performed
<!--- What did you do to ensure that this change is behaving as intended? This
should start with unit tests, but it's usually a good idea to try running
the code in a real setting. Include screenshots if you'd like, but make sure to
remove any personal information you won't want to share --->

Running the command:
```bash
 enderchest open -v --exclude foo --exclude bar --dry-run
```
and combining through the console output, I found the expected `--exclude`s in the resulting Rsync command.

```
Simulating an attempt to pull changes from rsync://couch-pc/home/openbagtwo/minecraft (Couch PC)
Executing the following command:
 /home/openbagtwo/.mambaforge/envs/enderchest/bin/rsync -shaz --delete --dry-run --stats -v --exclude EnderChest/enderchest.cfg --exclude EnderChest/.* --exclude .DS_Store --exclude foo --exclude bar couch-pc:/home/openbagtwo/minecraft/EnderChest minecraft
receiving incremental file list
```


## PR Type
<!--- Check all that apply --->
- [ ] This PR introduces a breaking change (will
  [require a bump in the minor version](https://semver.org/))
- [ ] The changes in this PR are high urgency and necessitate a hotfix or patch
  release (will require rebasing off of `release`)
- [ ] This is a release (staging) PR (maintainer use only)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.
      All bullets in this section are required to be checked off before the PR can
      be merged, but they don't need to be checked off before the PR is opened.
      If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] I have read [the contributor's guide](https://openbagtwo.github.io/EnderChest/dev/contrib/)
- [x] I have run `mkdocs serve` locally and ensured that all API docs and
  changes I have made to the static pages are rendering correctly, with all links
  working
- [x] All tech debt concerns have been resolved, documented as issues, or otherwise
  accepted
- [x] I agree to license my contribution to this project under
  [the GNU Public License v3](https://www.gnu.org/licenses/gpl-3.0.en.html)
  <!--- If you wish to use a different compatible license, please edit the above--->


<!--- Adapted from https://github.com/stevemao/github-issue-templates --->
