### PR TITLE
Do not place after open dry-runs

### DIFF
--- a/enderchest/remote.py
+++ b/enderchest/remote.py
@@ -235,7 +235,7 @@ def sync_with_remotes(
         else:
             synced_somewhere = True
             if pull_or_push == "pull":
-                if this_chest.place_after_open:
+                if this_chest.place_after_open and not dry_run:
                     place.place_ender_chest(
                         minecraft_root,
                         keep_broken_links=False,

--- a/enderchest/test/test_sync.py
+++ b/enderchest/test/test_sync.py
@@ -344,6 +344,27 @@ class TestFileSync:
 
         assert not test_path.exists()
 
+    def test_does_not_place_after_dry_run(self, minecraft_root, remote, caplog):
+        # TODO: move this into TestFileSyncOnly as there is no value in testing
+        #       this for multiple protocols
+
+        test_path = (
+            minecraft_root
+            / "instances"
+            / "axolotl"
+            / ".minecraft"
+            / "conflict"
+            / "diamond.png"
+        )
+        enderchest = gather.load_ender_chest(minecraft_root)
+        enderchest.register_remote(remote, alias="not so remote")
+        enderchest.place_after_open = True
+        enderchest.write_to_cfg(fs.ender_chest_config(minecraft_root))
+
+        r.sync_with_remotes(minecraft_root, "pull", verbosity=-1, dry_run=True)
+
+        assert not test_path.exists()
+
     @pytest.mark.parametrize("operation", ("pull", "push"))
     def test_timeout_argument_doesnt_obviously_break_(
         self, minecraft_root, remote, operation


### PR DESCRIPTION
## Summary
<!--- One sentence summary of this PR. Can oftentimes just be a matter of linking
      to the issue number --->

Fixes #108

## List of Changes
<!--- List out the changes introduced by this PR, permalinking
      (read: with commit hash) to the commit, file or section of code where
      that change was implemented --->

* Adds a check to prevent place-after-open if strictly running `dry-run` (as opposed a sync-confirm/wait)
* Adds a test for that check

## Tech Debt and Other Concerns
<!--- Use this section to call out anything in the code (including stuff you
      discovered outside of your contributions!) that you think may cause
      issues either now or further down the road. These will need to be spun
      off into issues before the PR is closed but shouldn't impede you opening
      the PR and starting the review process --->


<!--- Un-comment this section if this is still a work in progress. When doing
      so, please be sure to add (WIP), (Draft) or (DNM) in the PR title and
      open this PR as a draft

## To Do

--->


## Validation Performed
<!--- What did you do to ensure that this change is behaving as intended? This
should start with unit tests, but it's usually a good idea to try running
the code in a real setting. Include screenshots if you'd like, but make sure to
remove any personal information you won't want to share --->
- Performed an `enderchest open --dry-run` and confirmed that no linking operations took place after the dry run was reported
- Performed an `enderchest open` with `sync-confirmation-time = prompt` in my enderchest.cfg and confirmed that:
  - I still got my dry run report before the actual sync, and
  - then once the sync was complete, the `place` operations were performed as expected

## PR Type
<!--- Check all that apply --->
- [ ] This PR introduces a breaking change (will
  [require a bump in the minor version](https://semver.org/))
- [ ] The changes in this PR are high urgency and necessitate a hotfix or patch
  release (will require rebasing off of `release`)
- [ ] This is a release (staging) PR (maintainer use only)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.
      All bullets in this section are required to be checked off before the PR can
      be merged, but they don't need to be checked off before the PR is opened.
      If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] I have read [the contributor's guide](https://openbagtwo.github.io/EnderChest/dev/contrib/)
- [x] I have run `mkdocs serve` locally and ensured that all API docs and
  changes I have made to the static pages are rendering correctly, with all links
  working
- [x] All tech debt concerns have been resolved, documented as issues, or otherwise
  accepted
- [x] I agree to license my contribution to this project under
  [the GNU Public License v3](https://www.gnu.org/licenses/gpl-3.0.en.html)
  <!--- If you wish to use a different compatible license, please edit the above--->


<!--- Adapted from https://github.com/stevemao/github-issue-templates --->
