### PR TITLE
Enable sync confirmation from the command line

### DIFF
--- a/docs/contrib.md
+++ b/docs/contrib.md
@@ -119,6 +119,10 @@ There are a variety of other style conventions, especially around non-Python
 files, but they will be automatically enforced by
 [pre-commit](https://github.com/OpenBagTwo/EnderChest/blob/dev/.pre-commit-config.yaml).
 
+<!---  TODO: guidance over capitalization and punctuation
+       TODO: CLI help style guide
+--->
+
 ## Unit Testing
 
 While unit tests are not globally required, any PR will require validation that

--- a/enderchest/cli.py
+++ b/enderchest/cli.py
@@ -267,13 +267,13 @@ def generate_parsers() -> tuple[ArgumentParser, dict[str, ArgumentParser]]:
     # (the parsed args aren't actually used)
     enderchest_parser.add_argument(
         "action",
-        help=f"the action to perform. Options are:{root_description}",
+        help=f"The action to perform. Options are:{root_description}",
         type=str,
     )
     enderchest_parser.add_argument(
         "arguments",
         nargs="*",
-        help="any additional arguments for the specific action."
+        help="Any additional arguments for the specific action."
         " To learn more, try: enderchest {action} -h",
     )
 
@@ -289,7 +289,7 @@ def generate_parsers() -> tuple[ArgumentParser, dict[str, ArgumentParser]]:
                 "root",
                 nargs="?",
                 help=(
-                    "optionally specify your root minecraft directory."
+                    "Optionally specify your root minecraft directory."
                     "  If no path is given, the current working directory will be used."
                 ),
                 type=Path,
@@ -432,12 +432,14 @@ def generate_parsers() -> tuple[ArgumentParser, dict[str, ArgumentParser]]:
         action="count",
         default=0,
         help=(
-            "Shorthand for the above cleanup options:"
+            "shorthand for the above cleanup options:"
             " -k will --keep-stale-links,"
             " and -kk will --keep-broken-links as well"
         ),
     )
-    error_handling = place_parser.add_mutually_exclusive_group()
+    error_handling = place_parser.add_argument_group(
+        title="error handling"
+    ).add_mutually_exclusive_group()
     error_handling.add_argument(
         "--stop-at-first-failure",
         "-x",
@@ -508,7 +510,7 @@ def generate_parsers() -> tuple[ArgumentParser, dict[str, ArgumentParser]]:
         nargs="+",
         action="extend",
         help=(
-            "provide URIs (e.g. rsync://deck@my-steam-deck/home/deck/) of any"
+            "Provide URIs (e.g. rsync://deck@my-steam-deck/home/deck/) of any"
             " remote EnderChest installation to register with this one."
             "Note: you should not use this method if the alias (name) of the"
             "remote does not match the remote's hostname (in this example,"
@@ -531,7 +533,7 @@ def generate_parsers() -> tuple[ArgumentParser, dict[str, ArgumentParser]]:
     # list shulker options
     list_shulker_parser = action_parsers[f"{_list_aliases[0]} {_shulker_aliases[0]}"]
     list_shulker_parser.add_argument(
-        "shulker_box_name", help="The name of the shulker box to query"
+        "shulker_box_name", help="the name of the shulker box to query"
     )
 
     # open / close options
@@ -542,7 +544,7 @@ def generate_parsers() -> tuple[ArgumentParser, dict[str, ArgumentParser]]:
             "--dry-run",
             action="store_true",
             help=(
-                "Perform a dry run of the sync operation,"
+                "perform a dry run of the sync operation,"
                 " reporting the operations that will be performed"
                 " but not actually carrying them out"
             ),
@@ -559,24 +561,36 @@ def generate_parsers() -> tuple[ArgumentParser, dict[str, ArgumentParser]]:
             "-t",
             type=int,
             help=(
-                "Set a maximum number of seconds to try to sync to a remote chest"
+                "set a maximum number of seconds to try to sync to a remote chest"
                 " before giving up and going on to the next one"
             ),
         )
-        sync_confirm_wait = sync_parser.add_mutually_exclusive_group()
+        sync_confirm_wait = sync_parser.add_argument_group(
+            title="sync confirmation control",
+            description=(
+                "The default behavior when syncing EnderChests is to first perform a"
+                " dry run of every sync operation and then wait 5 seconds before"
+                " proceeding with the real sync. The idea is to give you time to"
+                " interrupt the sync if the dry run looks wrong. You can raise or"
+                " lower that wait time through these flags. You can also modify it"
+                " by editing the enderchest.cfg file."
+            ),
+        ).add_mutually_exclusive_group()
         sync_confirm_wait.add_argument(
             "--wait",
             "-w",
             dest="sync_confirm_wait",
             type=int,
-            help=(
-                "The default behavior when syncing EnderChests is to first perform a"
-                " dry run of every sync operation and then wait 5 seconds before"
-                " proceeding with the real sync. The idea is to give you time to"
-                " interrupt the sync if the dry run looks wrong. You can raise or"
-                " lower that wait time through this flag. You can also modify it"
-                " by editing the enderchest.cfg file."
-            ),
+            help="set the time in seconds to wait after performing a dry run"
+            " before the real sync is performed",
+        )
+        sync_confirm_wait.add_argument(
+            "--confirm",
+            "-c",
+            dest="sync_confirm_wait",
+            action="store_true",
+            help="after performing the dry run, explicitly ask for confirmation"
+            " before performing the real sync",
         )
 
     # test pass-through
@@ -595,7 +609,7 @@ def generate_parsers() -> tuple[ArgumentParser, dict[str, ArgumentParser]]:
     test_parser.add_argument(
         "pytest_args",
         nargs=argparse.REMAINDER,
-        help="Any additional arguments to pass through to py.test",
+        help="any additional arguments to pass through to py.test",
     )
 
     return enderchest_parser, action_parsers

--- a/enderchest/enderchest.py
+++ b/enderchest/enderchest.py
@@ -288,7 +288,7 @@ class EnderChest:
         ender_chest = EnderChest(uri, name, remotes, instances)
         if sync_confirm_wait is not None:
             match sync_confirm_wait.lower():
-                case "true" | "prompt" | "yes":
+                case "true" | "prompt" | "yes" | "confirm":
                     ender_chest.sync_confirm_wait = True
                 case "false" | "no" | "skip":
                     ender_chest.sync_confirm_wait = False

--- a/enderchest/test/test_config.py
+++ b/enderchest/test/test_config.py
@@ -178,13 +178,14 @@ class TestConfigParsing:
         with pytest.raises(ValueError, match="is not a valid URI"):
             _ = EnderChest.from_cfg(config_file)
 
-    def test_sync_confirm_wait_prompt_is_read_as_true(self, tmp_path):
+    @pytest.mark.parametrize("value", ("prompt", "CONFIRM"))
+    def test_sync_confirm_wait_prompt_is_read_as_true(self, tmp_path, value):
         config_file = tmp_path / "enderchest.cfg"
         config_file.write_text(
             "[properties]"
             "\nname=tester"
             "\nplace-after-open=no"
-            "\nsync-confirmation-time=prompt"
+            f"\nsync-confirmation-time={value}"
         )
         assert EnderChest.from_cfg(config_file).sync_confirm_wait is True
 


### PR DESCRIPTION
## Summary
<!--- One sentence summary of this PR. Can oftentimes just be a matter of linking
      to the issue number --->

Implements #97

## List of Changes
<!--- List out the changes introduced by this PR, permalinking
      (read: with commit hash) to the commit, file or section of code where
      that change was implemented --->

* Passing in the flag `--confirm` to `enderchest open` or `enderchest close` can now be used to explicitly prompt the user to explicitly confirm before syncing
* ```ini
   sync-confirmation-time=confirm
   ```
   is now an accepted the same way that "prompt" (and "yes") were accepted before
* I've cleaned up the CLI docs a little bit to make capitalization and punctuation more consistent and to group some of the mutually-exclusive groups into descriptive argument groups
  * _i.e_ running a `diff` on `enderchest close -h`:
    ```diff
    1,3c1
    < usage: enderchest close [-h] [--root ROOT_FLAG] [--verbose] [--quiet] [--dry-run] [--exclude EXCLUDE [EXCLUDE ...]]
    <                         [--timeout TIMEOUT] [--wait SYNC_CONFIRM_WAIT]
    <                         [root]
    ---
    > usage: enderchest close [-h] [--root ROOT_FLAG] [--verbose] [--quiet] [--dry-run] [--exclude EXCLUDE [EXCLUDE ...]] [--timeout TIMEOUT] [--wait SYNC_CONFIRM_WAIT | --confirm] [root]
    8,9c6
    <   root                  optionally specify your root minecraft directory. If no path is given, the current working directory will be
    <                         used.
    ---
    >   root                  Optionally specify your root minecraft directory. If no path is given, the current working directory will be used.
    16,17c13
    <   --dry-run             Perform a dry run of the sync operation, reporting the operations that will be performed but not actually
    <                         carrying them out
    ---
    >   --dry-run             perform a dry run of the sync operation, reporting the operations that will be performed but not actually carrying them out
    21,22c17,22
    <                         Set a maximum number of seconds to try to sync to a remote chest before giving up and going on to the next
    <                         one
    ---
    >                         set a maximum number of seconds to try to sync to a remote chest before giving up and going on to the next one
    > 
    > sync confirmation control:
    >   The default behavior when syncing EnderChests is to first perform a dry run of every sync operation and then wait 5 seconds before proceeding with the real sync. The idea is to give you time to interrupt the sync if the dry run looks wrong. You can raise or lower that wait time through these flags.
    >   You can also modify it by editing the enderchest.cfg file.
    > 
    24,27c24,25
    <                         The default behavior when syncing EnderChests is to first perform a dry run of every sync operation and then
    <                         wait 5 seconds before proceeding with the real sync. The idea is to give you time to interrupt the sync if
    <                         the dry run looks wrong. You can raise or lower that wait time through this flag. You can also modify it by
    <                         editing the enderchest.cfg file.
    ---
    >                         set the time in seconds to wait after performing a dry run before the real sync is performed
    >   --confirm, -c         after performing the dry run, explicitly ask for confirmation before performing the real sync
    ```
    

## Tech Debt and Other Concerns
<!--- Use this section to call out anything in the code (including stuff you
      discovered outside of your contributions!) that you think may cause
      issues either now or further down the road. These will need to be spun
      off into issues before the PR is closed but shouldn't impede you opening
      the PR and starting the review process --->


<!--- Un-comment this section if this is still a work in progress. When doing
      so, please be sure to add (WIP), (Draft) or (DNM) in the PR title and
      open this PR as a draft

## To Do

--->


## Validation Performed
<!--- What did you do to ensure that this change is behaving as intended? This
should start with unit tests, but it's usually a good idea to try running
the code in a real setting. Include screenshots if you'd like, but make sure to
remove any personal information you won't want to share --->

## PR Type
<!--- Check all that apply --->
- [ ] This PR introduces a breaking change (will
  [require a bump in the minor version](https://semver.org/))
- [ ] The changes in this PR are high urgency and necessitate a hotfix or patch
  release (will require rebasing off of `release`)
- [ ] This is a release (staging) PR (maintainer use only)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.
      All bullets in this section are required to be checked off before the PR can
      be merged, but they don't need to be checked off before the PR is opened.
      If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] I have read [the contributor's guide](https://openbagtwo.github.io/EnderChest/dev/contrib/)
- [x] I have run `mkdocs serve` locally and ensured that all API docs and
  changes I have made to the static pages are rendering correctly, with all links
  working
- [x] All tech debt concerns have been resolved, documented as issues, or otherwise
  accepted
- [x] I agree to license my contribution to this project under
  [the GNU Public License v3](https://www.gnu.org/licenses/gpl-3.0.en.html)
  <!--- If you wish to use a different compatible license, please edit the above--->


<!--- Adapted from https://github.com/stevemao/github-issue-templates --->
