### PR TITLE
Bugfix: make sure tags="*" matches groupless / tagless instances

### DIFF
--- a/enderchest/gather.py
+++ b/enderchest/gather.py
@@ -817,7 +817,7 @@ Read more: https://help.minecraft.net/hc/en-us/articles/16165590199181"""
         "Y/n",
     )
 
-    if response.lower() not in ("y", "yes"):
+    if response.lower() not in ("y", "yes", ""):
         return
 
     with symlink_allowlist.open("a") as allow_file:

--- a/enderchest/shulker_box.py
+++ b/enderchest/shulker_box.py
@@ -214,6 +214,8 @@ class ShulkerBox(NamedTuple):
                         return False
                 case "tags":
                     for value in values:
+                        if value == "*":  # in case instance.tags is empty
+                            break
                         if fnmatch.filter(
                             [tag.lower() for tag in instance.tags], value.lower()
                         ):

--- a/enderchest/test/test_craft.py
+++ b/enderchest/test/test_craft.py
@@ -165,7 +165,7 @@ class TestEnderChestCrafting:
             ),
         )
 
-        never = utils.scripted_prompt(["no"])
+        never = utils.scripted_prompt(["no"] * 2)
         monkeypatch.setattr("builtins.input", never)
 
         craft.craft_ender_chest(
@@ -180,7 +180,7 @@ class TestEnderChestCrafting:
         assert not [record for record in caplog.records if record.levelname == "ERROR"]
 
         chest = load_ender_chest(minecraft_root)
-        assert len(chest.instances) == 4
+        assert len(chest.instances) == 5
         assert len(chest.remotes) == 1
 
     @pytest.mark.parametrize("root_type", ("absolute", "relative"))
@@ -195,11 +195,11 @@ class TestEnderChestCrafting:
     ):
         if root_type == "absolute":
             root = minecraft_root
-            n_responses = 8
+            n_responses = 9
         else:
             root = Path(minecraft_root.name)
             monkeypatch.chdir(minecraft_root.parent)
-            n_responses = 9  # because now cwd != minecraft root
+            n_responses = 10  # because now cwd != minecraft root
 
         script_reader = utils.scripted_prompt([""] * n_responses)
         monkeypatch.setattr("builtins.input", script_reader)
@@ -210,7 +210,7 @@ class TestEnderChestCrafting:
 
         assert not [record for record in caplog.records if record.levelname == "ERROR"]
 
-        assert len(chest.instances) == 4
+        assert len(chest.instances) == 5
         assert len(chest.remotes) == 0
 
         # make sure all responses were used

--- a/enderchest/test/test_gather.py
+++ b/enderchest/test/test_gather.py
@@ -103,6 +103,7 @@ class TestLoadBoxInstanceMatches:
         instance_name_lookup = {
             "official": "~",
             "Chest Boat": "chest-boat",
+            "Drowned": "drowned",
         }
         box_lookup = {
             box.name: box
@@ -203,14 +204,14 @@ class TestGatherInstances:
             key=lambda instance: instance.name,
         )
 
-        assert len(instances) == 3
+        assert len(instances) == 4
 
         assert all(
             [
                 i.equals(
                     minecraft_root, instances[idx - 1], utils.TESTING_INSTANCES[idx]
                 )
-                for idx in range(1, 4)
+                for idx in range(1, 5)
             ]
         )
 
@@ -225,14 +226,14 @@ class TestGatherInstances:
             key=lambda instance: instance.name,
         )
 
-        assert len(instances) == 3
+        assert len(instances) == 4
 
         assert all(
             [
                 i.equals(
                     minecraft_root, instances[idx - 1], utils.TESTING_INSTANCES[idx]
                 )
-                for idx in range(1, 4)
+                for idx in range(1, 5)
             ]
         )
 
@@ -246,12 +247,12 @@ class TestGatherInstances:
             else "aaa",  # sorting hack
         )
 
-        assert len(instances) == 4
+        assert len(instances) == 5
 
         assert all(
             [
                 i.equals(minecraft_root, instances[idx], utils.TESTING_INSTANCES[idx])
-                for idx in range(4)
+                for idx in range(5)
             ]
         )
 
@@ -291,12 +292,12 @@ class TestGatherInstances:
             else "aaa",  # sorting hack
         )
 
-        assert len(instances) == 4
+        assert len(instances) == 5
 
         assert all(
             [
                 i.equals(minecraft_root, instances[idx], utils.TESTING_INSTANCES[idx])
-                for idx in range(4)
+                for idx in range(5)
             ]
         )
 
@@ -420,7 +421,7 @@ class TestSymlinkAllowlistHandling:
     def test_ender_chest_will_write_allowlists_with_consent(
         self, minecraft_root, home, monkeypatch, capsys
     ):
-        mkay = utils.scripted_prompt(["y"] * 2)
+        mkay = utils.scripted_prompt(["y"] * 3)
         monkeypatch.setattr("builtins.input", mkay)
 
         gather.gather_minecraft_instances(minecraft_root, home, True)

--- a/enderchest/test/test_place.py
+++ b/enderchest/test/test_place.py
@@ -1,4 +1,5 @@
 """Tests around instance-linking functionality"""
+import itertools
 import logging
 import os
 import re
@@ -500,8 +501,23 @@ class TestShulkerInstanceMatching:
             if shulker.matches(instance)
         ]
 
-    def test_shulker_box_with_no_match_conditions_matches_everything(self):
-        global_shulker = ShulkerBox(0, "global", Path("ignoreme"), (), ())
+    @pytest.mark.parametrize(
+        "star_instances, star_tags",
+        itertools.product(*((False, True),) * 2),
+        ids=("", "tags=*", "instances=*", "instances=*,tags=*"),
+    )
+    def test_shulker_box_with_no_match_conditions_matches_everything(
+        self, star_instances, star_tags
+    ):
+        match_criteria = []
+        if star_instances:
+            match_criteria.append(("instances", ("*",)))
+        if star_tags:
+            match_criteria.append(("tags", ("*",)))
+
+        global_shulker = ShulkerBox(
+            0, "global", Path("ignoreme"), tuple(match_criteria), ()
+        )
 
         assert self.matchall(global_shulker) == [
             instance.name for instance in utils.TESTING_INSTANCES
@@ -607,6 +623,7 @@ class TestShulkerInstanceMatching:
             "axolotl",
             "bee",
             "Chest Boat",
+            "Drowned",
         ]
 
     def test_loader_matching_knows_how_to_interpret_fabric_like(self, tmp_path):

--- a/enderchest/test/testing_files/enderchest.cfg
+++ b/enderchest/test/testing_files/enderchest.cfg
@@ -33,3 +33,10 @@ root = instances/chest-boat/.minecraft
 minecraft_version = 1.19.0
 modloader = Fabric Loader
 groups = Vanilla Plus
+
+[Drowned]
+root = instances/drowned/.minecraft
+minecraft_version = 1.20.2
+modloader = Quilt Loader
+groups =
+tags =

--- a/enderchest/test/utils.py
+++ b/enderchest/test/utils.py
@@ -352,6 +352,7 @@ MATCH_CSV = """, global, 1.19, vanilla, optifine, steamdeck
 axolotl        ,   True, False,   True,    False,     False
 bee            ,   True, False,  False,     True,     False
 chest-boat     ,   True, True,   False,    False,     False
+drowned        ,   True, False,  False,    False,     False
 """
 
 


### PR DESCRIPTION
## Summary
<!--- One sentence summary of this PR. Can oftentimes just be a matter of linking
      to the issue number --->

Fixes #114

## List of Changes
<!--- List out the changes introduced by this PR, permalinking
      (read: with commit hash) to the commit, file or section of code where
      that change was implemented --->

* 071269fd31a3e9bb39520dc804c81998448a8dad fixes #115 (discovered incidentally)
* Adds a new instance to the test suite with no groups and tags and updates the test suite to accomodate
* Adds new variations on match-all tests to ensure that wildcards work the same as omitting the match condition (for tags and instance names)
  * Looking ahead to #107, `minecraft=*` should not match non-Minecraft instances 

## Tech Debt and Other Concerns
<!--- Use this section to call out anything in the code (including stuff you
      discovered outside of your contributions!) that you think may cause
      issues either now or further down the road. These will need to be spun
      off into issues before the PR is closed but shouldn't impede you opening
      the PR and starting the review process --->


<!--- Un-comment this section if this is still a work in progress. When doing
      so, please be sure to add (WIP), (Draft) or (DNM) in the PR title and
      open this PR as a draft

## To Do

--->


## Validation Performed
<!--- What did you do to ensure that this change is behaving as intended? This
should start with unit tests, but it's usually a good idea to try running
the code in a real setting. Include screenshots if you'd like, but make sure to
remove any personal information you won't want to share --->
- I successfully crafted a new shulker box that links to my tagless instance
- `enderchest inventory minecraft Tagless` (where "Tagless" is the name of my tag/group-free instance) shows not just this newest shulker box, but _all_ of the shulker boxes that should be linked
- `enderchest place` created links inside Tagless pointing into the desired shulker boxes

## PR Type
<!--- Check all that apply --->
- [ ] This PR introduces a breaking change (will
  [require a bump in the minor version](https://semver.org/))
- [ ] The changes in this PR are high urgency and necessitate a hotfix or patch
  release (will require rebasing off of `release`)
- [ ] This is a release (staging) PR (maintainer use only)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.
      All bullets in this section are required to be checked off before the PR can
      be merged, but they don't need to be checked off before the PR is opened.
      If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] I have read [the contributor's guide](https://openbagtwo.github.io/EnderChest/dev/contrib/)
- [x] I have run `mkdocs serve` locally and ensured that all API docs and
  changes I have made to the static pages are rendering correctly, with all links
  working
- [x] All tech debt concerns have been resolved, documented as issues, or otherwise
  accepted
- [x] I agree to license my contribution to this project under
  [the GNU Public License v3](https://www.gnu.org/licenses/gpl-3.0.en.html)
  <!--- If you wish to use a different compatible license, please edit the above--->


<!--- Adapted from https://github.com/stevemao/github-issue-templates --->
