### PR TITLE
Rework Shulker Box Folder Settings

### DIFF
--- a/docs/suggestions.md
+++ b/docs/suggestions.md
@@ -85,7 +85,7 @@ start is their priority values):
     !!! note
         If you're creating your shulker box through the command-line interface,
         this is pretty much the only sort of box where I'd recommend selecting
-        the "Standard" set of linked-folders.
+        the "Global" set of linked-folders.
 
    This is also where I have a baseline `options.txt` file. It's almost certain
    to get replaced in the actual instance, but it saves me so much aggravation
@@ -199,7 +199,7 @@ From there, you then create a shulker box for each instance that contains
 _symlinks_ pointing into the files that live in the EnderChest (_e.g._
 `instance_shulker/options.txt -> _Chest Monster/options files/basic_options.txt`).
 
-Each instance will probably want to use the standard set of linked folders so
+Each instance will probably want to use the "Global" set of linked folders so
 that when an instance generates new screenshots, logs, crash reports, etc., they
 go into the EnderChest, and by making the "folders" inside of the shulker boxes
 _symlinks themselves_, they can point into either shared or separated folders

--- a/enderchest/enderchest.py
+++ b/enderchest/enderchest.py
@@ -37,6 +37,8 @@ _DEFAULTS = (
             "logs",
             "replay_recordings",
             "screenshots",
+            "schematics",
+            "config/litematica",  # still worth having in case max_depth>2
             ".bobby",
         ),
     ),

--- a/enderchest/enderchest.py
+++ b/enderchest/enderchest.py
@@ -110,6 +110,13 @@ class EnderChest:
         installations. By default, this list comprises `EnderChest/enderchest.cfg`,
         any top-level folders starting with a "." (like .git) and
         `.DS_Store` (for all you mac gamers).
+    shulker_box_folders : list of str
+        The folders that will be created inside each new shulker box
+    standard_link_folders : list of str
+        The default set of "link folders" when crafting a new shulker box
+    global_link_folders : list of str
+        The "global" set of "link folders," offered as a suggestion when
+        crafting a new shulker box
     """
 
     name: str

--- a/enderchest/shulker_box.py
+++ b/enderchest/shulker_box.py
@@ -2,7 +2,7 @@
 import fnmatch
 import os
 from pathlib import Path
-from typing import Any, NamedTuple
+from typing import Any, Iterable, NamedTuple
 
 import semantic_version as semver
 
@@ -299,26 +299,9 @@ def _matches_version(version_spec: str, version_string: str) -> bool:
         return fnmatch.fnmatchcase(version_string.lower(), version_spec.lower())
 
 
-DEFAULT_SHULKER_FOLDERS = (  # TODO: customize in enderchest.cfg
-    "config",
-    "mods",
-    "resourcepacks",
-    "saves",
-    "shaderpacks",
-)
-
-STANDARD_LINK_FOLDERS = (  # TODO: customize in enderchest.cfg
-    "backups",
-    "cachedImages",
-    "crash-reports",
-    "logs",
-    "replay_recordings",
-    "screenshots",
-    ".bobby",
-)
-
-
-def create_shulker_box(minecraft_root: Path, shulker_box: ShulkerBox) -> None:
+def create_shulker_box(
+    minecraft_root: Path, shulker_box: ShulkerBox, folders: Iterable[str]
+) -> None:
     """Create a shulker box folder based on the provided configuration
 
     Parameters
@@ -328,6 +311,8 @@ def create_shulker_box(minecraft_root: Path, shulker_box: ShulkerBox) -> None:
         that's the parent of your EnderChest folder)
     shulker_box : ShulkerBox
         The spec of the box to create
+    folders : list-like of str
+        The folders to create inside the shulker box (not including link folders)
 
     Notes
     -----
@@ -337,13 +322,13 @@ def create_shulker_box(minecraft_root: Path, shulker_box: ShulkerBox) -> None:
     - This method will fail if there is no EnderChest set up in the minecraft
       root
     - This method does not check to see if there is already a shulker box
-      set up at the specificed location--if one exists, its config will
+      set up at the specified location--if one exists, its config will
       be overwritten
     """
     root = fs.shulker_box_root(minecraft_root, shulker_box.name)
     root.mkdir(exist_ok=True)
 
-    for folder in (*DEFAULT_SHULKER_FOLDERS, *shulker_box.link_folders):
+    for folder in (*folders, *shulker_box.link_folders):
         CRAFT_LOGGER.debug(f"Creating {root / folder}")
         (root / folder).mkdir(exist_ok=True, parents=True)
 

--- a/enderchest/test/test_cli.py
+++ b/enderchest/test/test_cli.py
@@ -389,7 +389,7 @@ class TestGatherRemote(ActionTestSuite):
 class TestInventory(ActionTestSuite):
     action = "inventory"
 
-    def test_no_args_routes_to_load_shulker_boxes(self, monkeypatch):
+    def test_no_args_routes_to_load_shulker_boxes(self, monkeypatch) -> None:
         gather_log: list[tuple[str, dict]] = []
 
         def mock_load_shulker_boxes(root, **kwargs) -> None:
@@ -406,7 +406,7 @@ class TestInventory(ActionTestSuite):
     @pytest.mark.parametrize("action_version", ("short", "long"))
     def test_no_path_routes_to_boxes_matching_instance(
         self, monkeypatch, action_version
-    ):
+    ) -> None:
         gather_log: list[tuple[str, str, dict]] = []
 
         def mock_get_shulker_boxes_matching_instance(root, name, **kwargs) -> None:
@@ -440,7 +440,7 @@ class TestInventory(ActionTestSuite):
     )
     def test_providing_a_path_always_routes_to_list_placements(
         self, monkeypatch, instance_how
-    ):
+    ) -> None:
         def mock_get_shulker_boxes_matching_instance(*args, **kwargs) -> None:
             raise AssertionError("I should not have been called!")
 
@@ -461,13 +461,15 @@ class TestInventory(ActionTestSuite):
             mock_list_placements,
         )
 
-        instance = None if instance_how == "no_instance" else "cherry grove"
         if instance_how == "no_instance":
-            instance_args = []
-        elif instance_how == "long_action":
-            instance_args = ["instance", instance]
-        else:  # if instance_how == "short_action":
-            instance_args = ["-i", instance]
+            instance = None
+            instance_args: list[str] = []
+        else:
+            instance = "cherry grove"
+            if instance_how == "long_action":
+                instance_args = ["instance", instance]
+            else:  # if instance_how == "short_action":
+                instance_args = ["-i", instance]
 
         action, root, _, kwargs = cli.parse_args(
             ["enderchest", *self.action.split(), *instance_args, "-p", "of_jelly.jar"]

--- a/enderchest/test/test_config.py
+++ b/enderchest/test/test_config.py
@@ -8,6 +8,7 @@ import pytest
 from enderchest import EnderChest, InstanceSpec, ShulkerBox
 from enderchest import config as cfg
 from enderchest import filesystem as fs
+from enderchest.enderchest import _DEFAULTS
 from enderchest.gather import load_shulker_boxes
 from enderchest.shulker_box import create_shulker_box
 from enderchest.test import utils
@@ -67,7 +68,9 @@ class TestConfigWriting:
 
         utils.pre_populate_enderchest(minecraft_root / "EnderChest")
 
-        create_shulker_box(minecraft_root, original_shulker)
+        create_shulker_box(
+            minecraft_root, original_shulker, dict(_DEFAULTS)["shulker_box_folders"]
+        )
 
         parsed_boxes = load_shulker_boxes(minecraft_root)
 

--- a/enderchest/test/test_gather.py
+++ b/enderchest/test/test_gather.py
@@ -280,7 +280,7 @@ class TestGatherInstances:
             fs.ender_chest_config(minecraft_root).read_text("utf-8").splitlines()
         )
         # this is a horrible way tp do this
-        ec_config[7] = "offer-to-update-symlink-allowlist = False"
+        ec_config[6] = "offer-to-update-symlink-allowlist = False"
         fs.ender_chest_config(minecraft_root).write_text("\n".join(ec_config))
         assert gather.load_ender_chest(minecraft_root).instances == ()
         gather.update_ender_chest(minecraft_root, (home, minecraft_root / "instances"))

--- a/enderchest/test/utils.py
+++ b/enderchest/test/utils.py
@@ -225,7 +225,7 @@ def populate_instances_folder(instances_folder: Path) -> None:
 
 def pre_populate_enderchest(
     enderchest_folder: Path,
-    *shulkers: tuple[str, str],
+    *boxes: tuple[str, str],
 ) -> list[ShulkerBox]:
     """Create an EnderChest folder, pre-populated with the testing enderchest.cfg
     folder and the specified shulker boxes
@@ -234,7 +234,7 @@ def pre_populate_enderchest(
     ----------
     enderchest_folder : Path
         The path of the EnderChest folder
-    *shulkers : 2-tuple of str
+    *boxes : 2-tuple of str
         Shulker boxes to populate, with tuple members of:
           - name : the folder name of the shulker
           - config : the contents of the config file
@@ -249,7 +249,7 @@ def pre_populate_enderchest(
     with as_file(testing_files.ENDERCHEST_CONFIG) as config_file:
         shutil.copy(config_file, enderchest_folder)
     shulker_boxes: list[ShulkerBox] = []
-    for shulker_name, shulker_config in shulkers:
+    for shulker_name, shulker_config in boxes:
         (enderchest_folder / shulker_name).mkdir(parents=True, exist_ok=True)
         config_path = enderchest_folder / shulker_name / fs.SHULKER_BOX_CONFIG_NAME
         with config_path.open("w") as config_file:


### PR DESCRIPTION
## Summary
<!--- One sentence summary of this PR. Can oftentimes just be a matter of linking
      to the issue number --->

Resolves #105

## List of Changes
<!--- List out the changes introduced by this PR, permalinking
      (read: with commit hash) to the commit, file or section of code where
      that change was implemented --->

* Centralizes all EnderChest configuration defaults into one single `_DEFAULTS` lookup
* Anything listed in `_DEFAULTS` can now be overwritten in `enderchest.cfg`, including the list of default folders inside a shulker box and the "standard" and "global" lists of link-folders
  * To this end, "Standard" is now "Global" and "nothing" is now the "Standard"
    * The docs have been updated to reflect this
  * Additionally, "Standard" is now default in the shulker box crafting prompt
* Resolved some TODOs about unnecessarily repeated EnderChest loading
* Added the litematica folders to the "global" set of link folders, resolving #105 

## Tech Debt and Other Concerns
<!--- Use this section to call out anything in the code (including stuff you
      discovered outside of your contributions!) that you think may cause
      issues either now or further down the road. These will need to be spun
      off into issues before the PR is closed but shouldn't impede you opening
      the PR and starting the review process --->

Since these folder settings aren't written to the config if they're not already in the config, it might be worth creating a definitive configuration guide. Then again, #80 is another way to solve this issue.

<!--- Un-comment this section if this is still a work in progress. When doing
      so, please be sure to add (WIP), (Draft) or (DNM) in the PR title and
      open this PR as a draft

## To Do

--->


## Validation Performed
<!--- What did you do to ensure that this change is behaving as intended? This
should start with unit tests, but it's usually a good idea to try running
the code in a real setting. Include screenshots if you'd like, but make sure to
remove any personal information you won't want to share --->
- Added an explicit test to make sure `config/litematica` is a link-folder in a "global" shulker box
- Updated my enderchest.cfg and confirmed that everything is looking good and roundtripping successfully
- Went through the `enderchest craft shulker_box` prompt a few times until I was satisfied with the prompt message and the general user experience of specifying global vs. standard vs. none vs. manual

## PR Type
<!--- Check all that apply --->
- [ ] This PR introduces a breaking change (will [require a bump in the minor version](https://semver.org/))
- [ ] The changes in this PR are high urgency and necessitate a hotfix or patch
  release (will require rebasing off of `release`)
- [ ] This is a release (staging) PR (maintainer use only)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.
      All bullets in this section are required to be checked off before the PR can
      be merged, but they don't need to be checked off before the PR is opened.
      If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] I have read [the contributor's guide](https://openbagtwo.github.io/EnderChest/dev/contrib/)
- [x] I have run `mkdocs serve` locally and ensured that all API docs and
  changes I have made to the static pages are rendering correctly, with all links
  working
- [x] All tech debt concerns have been resolved, documented as issues, or otherwise
  accepted
- [x] I agree to license my contribution to this project under
  [the GNU Public License v3](https://www.gnu.org/licenses/gpl-3.0.en.html)
  <!--- If you wish to use a different compatible license, please edit the above--->


<!--- Adapted from https://github.com/stevemao/github-issue-templates --->
