### PR TITLE
Add functionality for offloading specific instances

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,25 +1,25 @@
 repos:
 - repo: https://github.com/psf/black
-  rev: 23.10.1
+  rev: 24.4.2
   hooks:
   - id: black
 - repo: https://github.com/pycqa/isort
-  rev: 5.12.0
+  rev: 5.13.2
   hooks:
   - id: isort
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.6.1
+  rev: v1.10.0
   hooks:
   - id: mypy
     additional_dependencies: [types-paramiko]
 - repo: https://github.com/nbQA-dev/nbQA
-  rev: 1.7.0
+  rev: 1.8.5
   hooks:
   - id: nbqa-isort
   - id: nbqa-mypy
     args: [--ignore-missing-imports]
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-  rev: v2.11.0
+  rev: v2.13.0
   hooks:
   - id: pretty-format-ini
     args: [--autofix]
@@ -27,7 +27,7 @@ repos:
   - id: pretty-format-yaml
     args: [--autofix]
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v4.6.0
   hooks:
   - id: check-json
   - id: pretty-format-json

--- a/docs/gen_clidocs.py
+++ b/docs/gen_clidocs.py
@@ -1,4 +1,5 @@
 """Generate CLI docs"""
+
 import mkdocs_gen_files
 
 from enderchest import cli

--- a/enderchest/__init__.py
+++ b/enderchest/__init__.py
@@ -1,4 +1,5 @@
 """Top-level imports"""
+
 from . import _version
 from .enderchest import EnderChest
 from .instance import InstanceSpec

--- a/enderchest/cli.py
+++ b/enderchest/cli.py
@@ -169,6 +169,14 @@ def _test(
         raise SystemExit(f"Tests Failed with exit code: {exit_code}")
 
 
+def _break(minecraft_root: Path, instances: Iterable[str] | None = None):
+    """Router for the break verb"""
+    if not instances:
+        uninstall.break_ender_chest(minecraft_root)
+    else:
+        uninstall.break_instances(minecraft_root, instances)
+
+
 ACTIONS: tuple[tuple[tuple[str, ...], str, Action], ...] = (
     # action names (first one is canonical), action description, action method
     (
@@ -270,9 +278,9 @@ ACTIONS: tuple[tuple[tuple[str, ...], str, Action], ...] = (
     ),
     (
         ("break",),
-        "uninstall EnderChest by copying all linked resources"
-        " into its registered instances",
-        uninstall.break_ender_chest,
+        "uninstall EnderChest by copying linked resources"
+        " into some or all of the registered instances",
+        _break,
     ),
     (
         ("test",),
@@ -338,15 +346,16 @@ def generate_parsers() -> tuple[ArgumentParser, dict[str, ArgumentParser]]:
         )
         if verb != "test":
             root = parser.add_mutually_exclusive_group()
-            root.add_argument(
-                "root",
-                nargs="?",
-                help=(
-                    "optionally specify your root minecraft directory."
-                    "  If no path is given, the current working directory will be used."
-                ),
-                type=Path,
-            )
+            if verb != "break":
+                root.add_argument(
+                    "root",
+                    nargs="?",
+                    help=(
+                        "optionally specify your root minecraft directory."
+                        "  If no path is given, the current working directory will be used."
+                    ),
+                    type=Path,
+                )
             root.add_argument(
                 "--root",
                 dest="root_flag",
@@ -689,6 +698,14 @@ def generate_parsers() -> tuple[ArgumentParser, dict[str, ArgumentParser]]:
             " before performing the real sync",
         )
 
+    break_parser = action_parsers["break"]
+    break_parser.add_argument(
+        "instances",
+        nargs="*",
+        help="instead of breaking your entire EnderChest, just deregister and"
+        " copy linked resources into the specified instances (by name)",
+    )
+
     # test pass-through
     test_parser = action_parsers["test"]
     test_parser.add_argument(
@@ -765,7 +782,7 @@ def parse_args(argv: Sequence[str]) -> tuple[Action, Path, int, dict[str, Any]]:
 
             action = actions[aliases[command]]
 
-            root_arg = action_kwargs.pop("root")
+            root_arg = None if command == "break" else action_kwargs.pop("root")
             root_flag = action_kwargs.pop("root_flag")
 
             verbosity = action_kwargs.pop("verbose") - action_kwargs.pop("quiet")

--- a/enderchest/cli.py
+++ b/enderchest/cli.py
@@ -27,8 +27,7 @@ _list_aliases = ("inventory", "list")
 class Action(Protocol):  # pragma: no cover
     """Common protocol for CLI actions"""
 
-    def __call__(self, minecraft_root: Path, /) -> Any:
-        ...
+    def __call__(self, minecraft_root: Path, /) -> Any: ...
 
 
 def _place(

--- a/enderchest/config.py
+++ b/enderchest/config.py
@@ -1,4 +1,5 @@
 """Helpers for parsing and writing INI-format config files"""
+
 import ast
 import datetime as dt
 from configparser import ConfigParser, ParsingError

--- a/enderchest/prompt.py
+++ b/enderchest/prompt.py
@@ -61,7 +61,7 @@ def confirm(default: bool) -> bool:
         Whether the user has opted to continue
     """
 
-    response = prompt("Do you wish to continue?", "Y/n" if default else "y/N")
+    response = prompt("Do you wish to continue?", "Y/n" if default else "y/N").lower()
 
     if response == "":
         return default

--- a/enderchest/prompt.py
+++ b/enderchest/prompt.py
@@ -1,4 +1,5 @@
 """Utilities for helping build interactive prompts"""
+
 import getpass
 
 CURSOR = "\x1b[35;1m==>\x1b[0m"

--- a/enderchest/sync/__init__.py
+++ b/enderchest/sync/__init__.py
@@ -1,4 +1,5 @@
 """Low-level functionality for synchronizing across different machines"""
+
 import importlib
 from contextlib import contextmanager
 from pathlib import Path

--- a/enderchest/sync/file.py
+++ b/enderchest/sync/file.py
@@ -1,4 +1,5 @@
 """shutil-based sync implementation"""
+
 import fnmatch
 import logging
 import os

--- a/enderchest/sync/rsync.py
+++ b/enderchest/sync/rsync.py
@@ -1,4 +1,5 @@
 """rsync sync implementation. Relies on the user having rsync installed on their system"""
+
 import os.path
 import re
 import shutil

--- a/enderchest/sync/sftp.py
+++ b/enderchest/sync/sftp.py
@@ -1,4 +1,5 @@
 """paramiko-based sftp sync implementation"""
+
 import os
 import posixpath
 import stat

--- a/enderchest/sync/utils.py
+++ b/enderchest/sync/utils.py
@@ -91,16 +91,13 @@ def render_remote(alias: str, uri: ParseResult) -> str:
 
 class _StatLike(Protocol):  # pragma: no cover
     @property
-    def st_mode(self) -> int | None:
-        ...
+    def st_mode(self) -> int | None: ...
 
     @property
-    def st_size(self) -> float | None:
-        ...
+    def st_size(self) -> float | None: ...
 
     @property
-    def st_mtime(self) -> float | None:
-        ...
+    def st_mtime(self) -> float | None: ...
 
 
 def is_identical(object_one: _StatLike, object_two: _StatLike) -> bool:

--- a/enderchest/test/conftest.py
+++ b/enderchest/test/conftest.py
@@ -1,4 +1,5 @@
 """Useful setup / teardown fixtures"""
+
 from importlib.resources import as_file
 from pathlib import Path
 from typing import Generator

--- a/enderchest/test/mock_paramiko.py
+++ b/enderchest/test/mock_paramiko.py
@@ -1,4 +1,5 @@
 """A mock Paramiko SFTP client to be used for testing on systems without local SSH"""
+
 import json
 import os
 import shutil

--- a/enderchest/test/test_break.py
+++ b/enderchest/test/test_break.py
@@ -1,4 +1,5 @@
 """Tests of the EnderChest uninstallation procedure"""
+
 import logging
 import os
 from pathlib import Path

--- a/enderchest/test/test_break.py
+++ b/enderchest/test/test_break.py
@@ -2,18 +2,28 @@
 
 import logging
 import os
-from pathlib import Path
 
 import pytest
 
 from enderchest import craft
 from enderchest import filesystem as fs
-from enderchest import gather, place, uninstall
+from enderchest import inventory, place, uninstall
 
 from . import utils
 
 
 class TestBreakEnderChest:
+
+    @pytest.fixture(autouse=True)
+    def patch_break(self, monkeypatch):
+        """Patch the actual break method to prevent accidental breakages
+        and to assert that the break method was never called"""
+
+        def mock_break(*args, **kwargs):
+            raise AssertionError("I should not have been called")
+
+        monkeypatch.setattr(uninstall, "_break", mock_break)
+
     def test_cant_break_what_doesnt_exist(self, tmp_path, caplog):
         uninstall.break_ender_chest(tmp_path)
         error_log = [
@@ -59,6 +69,112 @@ class TestBreakEnderChest:
         assert errorish_log[-2].message.startswith("Are you sure")
 
         assert len(errorish_log) == 2
+
+
+class TestPartiallyBreakEnderChest:
+    @pytest.fixture(autouse=True)
+    def patch_break(self, monkeypatch):
+        """Patch the actual break method to prevent accidental breakages
+        and to assert that the break method was never called"""
+
+        def mock_break(*args, **kwargs):
+            raise AssertionError("I should not have been called")
+
+        monkeypatch.setattr(uninstall, "_break", mock_break)
+
+    def test_cant_break_what_doesnt_exist(self, tmp_path, caplog):
+        with pytest.raises(FileNotFoundError, match="No valid EnderChest"):
+            uninstall.break_instances(tmp_path, ("potato", "infinite"))
+
+    def test_break_aborts_for_a_chest_with_no_instances(self, tmp_path, caplog):
+        craft.craft_ender_chest(
+            tmp_path,
+            instance_search_paths=[],  # gotta give a kwarg so it doesn't go interactive
+        )
+        uninstall.break_instances(tmp_path, ("bee", "Drowned"))
+        errorish_log = [
+            record for record in caplog.records if record.levelno >= logging.WARNING
+        ]
+        assert errorish_log[-1].message.splitlines()[-1] == "Aborting."
+        assert "no valid instances" in errorish_log[-1].message.lower()
+
+    def test_break_asks_you_if_youre_really_sure(
+        self, minecraft_root, home, monkeypatch, capsys, caplog
+    ):
+        script_reader = utils.scripted_prompt([""])
+        monkeypatch.setattr("builtins.input", script_reader)
+
+        utils.pre_populate_enderchest(
+            fs.ender_chest_folder(minecraft_root, check_exists=False),
+            *utils.TESTING_SHULKER_CONFIGS
+        )
+
+        uninstall.break_instances(minecraft_root, ("bee", "Drowned"))
+
+        _ = capsys.readouterr()  # suppress outputs
+        errorish_log = [
+            record for record in caplog.records if record.levelno >= logging.WARNING
+        ]
+        assert errorish_log[-1].message == "Aborting."
+
+        assert errorish_log[-2].levelno == logging.WARNING
+        assert errorish_log[-2].message.startswith("Are you sure")
+        assert "  - bee\n  - Drowned" in errorish_log[-2].message
+
+        assert len(errorish_log) == 2
+
+    def test_break_skips_invalid_instances(
+        self, minecraft_root, home, monkeypatch, capsys, caplog
+    ):
+        script_reader = utils.scripted_prompt([""])
+        monkeypatch.setattr("builtins.input", script_reader)
+
+        utils.pre_populate_enderchest(
+            fs.ender_chest_folder(minecraft_root, check_exists=False),
+            *utils.TESTING_SHULKER_CONFIGS
+        )
+
+        uninstall.break_instances(minecraft_root, ("bee", "drowned"))
+
+        _ = capsys.readouterr()  # suppress outputs
+        errorish_log = [
+            record for record in caplog.records if record.levelno >= logging.WARNING
+        ]
+        assert len(errorish_log) == 3
+        assert errorish_log[-3].levelno == logging.WARNING
+        assert "drowned" in errorish_log[-3].message
+        assert errorish_log[-3].message.lower().endswith("skipping.")
+
+    def test_break_deregisters_instances_afterwards(
+        self, minecraft_root, home, monkeypatch, capsys, caplog
+    ):
+        script_reader = utils.scripted_prompt(["Y"])
+        monkeypatch.setattr("builtins.input", script_reader)
+
+        def mock_break(*args, **kwargs):
+            print("Hi mom")
+            pass
+
+        monkeypatch.setattr(uninstall, "_break", mock_break)
+
+        utils.pre_populate_enderchest(
+            fs.ender_chest_folder(minecraft_root, check_exists=False),
+            *utils.TESTING_SHULKER_CONFIGS
+        )
+
+        assert "bee" in (
+            instance.name
+            for instance in inventory.load_ender_chest_instances(minecraft_root)
+        )
+
+        uninstall.break_instances(minecraft_root, ("bee", "drowned"))
+
+        _ = capsys.readouterr()  # suppress outputs
+
+        assert "bee" not in (
+            instance.name
+            for instance in inventory.load_ender_chest_instances(minecraft_root)
+        )
 
 
 class TestBreaking:

--- a/enderchest/test/test_cli.py
+++ b/enderchest/test/test_cli.py
@@ -46,6 +46,7 @@ class TestVersion:
 
 
 class ActionTestSuite:
+    action: str
     required_args: tuple[str, ...] = ()
 
     @pytest.mark.parametrize("help_flag", ("-h", "--help"))

--- a/enderchest/test/test_cli.py
+++ b/enderchest/test/test_cli.py
@@ -8,7 +8,7 @@ from typing import Generator
 import pytest
 
 import enderchest
-from enderchest import cli, inventory, place, remote
+from enderchest import cli, inventory, place, remote, uninstall
 
 
 class TestHelp:
@@ -682,3 +682,64 @@ class TestClose(TestOpen):
 
 class TestBreak(ActionTestSuite):
     action = "break"
+
+    @pytest.fixture(autouse=True)
+    def prevent_actual_breakage(self, monkeypatch):
+        def mock_break(*args, **kwargs):
+            raise AssertionError("I should not have been called")
+
+        monkeypatch.setattr(uninstall, "_break", mock_break)
+
+    @pytest.fixture
+    def call_logs(self, monkeypatch):
+        full_uninstall_calls = []
+        partial_uninstall_calls = []
+
+        def mock_full_uninstall(*args, **kwargs):
+            full_uninstall_calls.append((args, kwargs))
+
+        def mock_partial_uninstall(*args, **kwargs):
+            partial_uninstall_calls.append((args, kwargs))
+
+        monkeypatch.setattr(uninstall, "break_ender_chest", mock_full_uninstall)
+        monkeypatch.setattr(uninstall, "break_instances", mock_partial_uninstall)
+
+        return {"full": full_uninstall_calls, "partial": partial_uninstall_calls}
+
+    @pytest.mark.parametrize("extra_flags", ("-v", "-q", "--root minceraft"))
+    def test_no_instance_names_routes_to_complete_uninstall(
+        self, call_logs, extra_flags
+    ):
+        action, root, _, kwargs = cli.parse_args(
+            [
+                "enderchest",
+                *self.action.split(),
+                *extra_flags.split(),
+            ]
+        )
+        action(root, **kwargs)
+        assert len(call_logs["partial"]) == 0
+        assert len(call_logs["full"]) == 1
+
+    @pytest.mark.parametrize("n_instances", (1, 2))
+    @pytest.mark.parametrize("extra_flags", ("-v", "-q", "--root minceraft"))
+    def test_providing_instance_names_routes_to_partial_uninstall(
+        self, call_logs, extra_flags, n_instances
+    ):
+        args = ["potato", "infinity"][:n_instances]
+        action, root, _, kwargs = cli.parse_args(
+            [
+                "enderchest",
+                *self.action.split(),
+                *args,
+                *extra_flags.split(),
+            ]
+        )
+        action(root, **kwargs)
+        assert len(call_logs["full"]) == 0
+        assert len(call_logs["partial"]) == 1
+        assert call_logs["partial"][0][0][1:] == (["potato", "infinity"][:n_instances],)
+
+    def test_first_argument_is_root(self):
+        """Because it's not"""
+        pass

--- a/enderchest/test/test_gather.py
+++ b/enderchest/test/test_gather.py
@@ -300,7 +300,7 @@ class TestGatherServer:
             )
         return expected_metadata
 
-    def test_parsing_metadata_from_jar(self, server_jars):
+    def test_parsing_metadata_from_jar(self, server_jars) -> None:
         expected: list[tuple[Path, tuple[str], str]] = [
             (jar, instance.minecraft_versions, instance.modloader)
             for jar, instance in server_jars.items()

--- a/enderchest/test/test_sync_utils.py
+++ b/enderchest/test/test_sync_utils.py
@@ -1,4 +1,5 @@
 """Tests of the sync-helper utilities"""
+
 import importlib
 import logging
 import os

--- a/enderchest/test/testing_files/__init__.py
+++ b/enderchest/test/testing_files/__init__.py
@@ -1,4 +1,5 @@
 """Subpackage containing all files and templates used for testing"""
+
 from importlib.resources import files
 
 __all__ = [

--- a/enderchest/test/utils.py
+++ b/enderchest/test/utils.py
@@ -1,4 +1,5 @@
 """Testing utilities"""
+
 import json
 import shutil
 from importlib.resources import as_file

--- a/enderchest/uninstall.py
+++ b/enderchest/uninstall.py
@@ -39,7 +39,16 @@ def break_ender_chest(minecraft_root: Path) -> None:
         BREAK_LOGGER.error("Aborting.")
         return
 
-    _break(fs.ender_chest_folder(minecraft_root), instances)
+    chest_folder = fs.ender_chest_folder(minecraft_root)
+    _break(chest_folder, instances)
+
+    BREAK_LOGGER.log(
+        IMPORTANT,
+        "EnderChest has been uninstalled."
+        "\nYou may now delete %s"
+        "\nand uninstall the EnderChest package",
+        chest_folder,
+    )
 
 
 def break_instances(minecraft_root: Path, instance_names: Iterable[str]) -> None:
@@ -160,11 +169,3 @@ def _break(
                     resource_path,
                     copy_fail,
                 )
-
-    BREAK_LOGGER.log(
-        IMPORTANT,
-        "EnderChest has been uninstalled."
-        "\nYou may now delete %s"
-        "\nand uninstall the EnderChest package",
-        chest_folder,
-    )

--- a/enderchest/uninstall.py
+++ b/enderchest/uninstall.py
@@ -1,13 +1,15 @@
 """Functionality for copying all files into their instances"""
 
+import logging
 import os
 import shutil
 from pathlib import Path
 from typing import Iterable
 
 from . import filesystem as fs
+from .enderchest import create_ender_chest
 from .instance import InstanceSpec
-from .inventory import load_ender_chest_instances
+from .inventory import load_ender_chest, load_ender_chest_instances
 from .loggers import BREAK_LOGGER, IMPORTANT
 from .prompt import confirm
 
@@ -40,11 +42,58 @@ def break_ender_chest(minecraft_root: Path) -> None:
     _break(fs.ender_chest_folder(minecraft_root), instances)
 
 
+def break_instances(minecraft_root: Path, instance_names: Iterable[str]) -> None:
+    """Deregister the specified instances from EnderChest, replacing all
+    instance symlinks with their actual targets, and then removing those
+    instances from the enderchest.cfg
+
+    Parameters
+    ----------
+    minecraft_root : Path
+        The root directory that your minecraft stuff (or, at least, the one
+        that's the parent of your EnderChest folder)
+    instance_names : list of str
+        The names of the instances to break
+    """
+    ender_chest = load_ender_chest(minecraft_root)
+
+    instance_lookup = {instance.name: instance for instance in ender_chest.instances}
+    instances: list[InstanceSpec] = []
+    for name in instance_names:
+        try:
+            instances.append(instance_lookup[name])
+        except KeyError:
+            BREAK_LOGGER.warning(
+                f'No instance named "{name}" is registered to this EnderChest.'
+                "\nSkipping."
+            )
+    if len(instances) == 0:
+        BREAK_LOGGER.error("No valid instances specified.\nAborting.")
+        return
+
+    BREAK_LOGGER.warning(
+        "Are you sure you want to remove the following instances from your EnderChest?"
+        + "\n"
+        + "\n".join((f"  - {instance.name}" for instance in instances))
+        + "\nDoing so will replace ALL the symlinks in each of the above instances"
+        "\nwith copies of their EnderChest-linked targets."
+        "\n\nTHIS CANNOT EASILY BE UNDONE!!"
+    )
+    if not confirm(default=False):
+        BREAK_LOGGER.error("Aborting.")
+        return
+
+    _break(fs.ender_chest_folder(minecraft_root), instances)
+    for instance in instances:
+        ender_chest._instances.remove(instance)
+    create_ender_chest(minecraft_root, ender_chest)
+
+
 def _break(
     chest_folder: Path,
     instances: Iterable[InstanceSpec],
 ) -> None:
-    """Actually perform the uninstallation (separated out for ease of mocking / testing)
+    """Actually perform the uninstallation
 
     Parameters
     ----------


### PR DESCRIPTION
## Summary
<!--- One sentence summary of this PR. Can oftentimes just be a matter of linking
      to the issue number --->

Addresses #123

## List of Changes
<!--- List out the changes introduced by this PR, permalinking
      (read: with commit hash) to the commit, file or section of code where
      that change was implemented --->

* Pre-commit bump and auto-lint
* `$enderchest break [instance names...]` will:
  1. check if the specified instances are registered to the chest (case sensitive)
  2. replace symlinks into the EnderChest folder from those instances with file copies
  3. deregister those instances from the chest

## Tech Debt and Other Concerns
<!--- Use this section to call out anything in the code (including stuff you
      discovered outside of your contributions!) that you think may cause
      issues either now or further down the road. These will need to be spun
      off into issues before the PR is closed but shouldn't impede you opening
      the PR and starting the review process --->
Not tech debt, but just wanted to note that this is the only action—besides test—that does not accept the Minecraft root as a positional argument (though the `--root root` flag still works), as it was too confusing trying to disambiguate the root from instance names. This is technically breaking backwards compatibility... but only for people who had previously fully uninstalled EnderChest.


<!--- Un-comment this section if this is still a work in progress. When doing
      so, please be sure to add (WIP), (Draft) or (DNM) in the PR title and
      open this PR as a draft

## To Do

--->


## Validation Performed
<!--- What did you do to ensure that this change is behaving as intended? This
should start with unit tests, but it's usually a good idea to try running
the code in a real setting. Include screenshots if you'd like, but make sure to
remove any personal information you won't want to share --->
- [x] I have run this command to take an instance that was previously registered to EnderChest and verified that, post `break`, all the files were still in place, and the instance was still launchable / playable as before 

## PR Type
<!--- Check all that apply --->
- [x] This PR introduces a breaking change ~~(will
  [require a bump in the minor version](https://semver.org/))~~
- [ ] The changes in this PR are high urgency and necessitate a hotfix or patch
  release (will require rebasing off of `release`)
- [ ] This is a release (staging) PR (maintainer use only)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.
      All bullets in this section are required to be checked off before the PR can
      be merged, but they don't need to be checked off before the PR is opened.
      If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] I have read [the contributor's guide](https://openbagtwo.github.io/EnderChest/dev/contrib/)
- [x] I have run `mkdocs serve` locally and ensured that all API docs and
  changes I have made to the static pages are rendering correctly, with all links
  working
- [x] All tech debt concerns have been resolved, documented as issues, or otherwise
  accepted
- [x] I agree to license my contribution to this project under
  [the GNU Public License v3](https://www.gnu.org/licenses/gpl-3.0.en.html)
  <!--- If you wish to use a different compatible license, please edit the above--->


<!--- Adapted from https://github.com/stevemao/github-issue-templates --->
