### PR TITLE
Allow discovery of "minecraft" folders (without dots)

### DIFF
--- a/enderchest/_version.py
+++ b/enderchest/_version.py
@@ -16,7 +16,7 @@ import os
 import re
 import subprocess
 import sys
-from typing import Callable, Dict
+from collections.abc import Callable
 
 
 def get_keywords():
@@ -54,8 +54,8 @@ class NotThisMethod(Exception):
     """Exception raised if a method is not valid for the current scenario."""
 
 
-LONG_VERSION_PY: Dict[str, str] = {}
-HANDLERS: Dict[str, Dict[str, Callable]] = {}
+LONG_VERSION_PY: dict[str, str] = {}
+HANDLERS: dict[str, dict[str, Callable]] = {}
 
 
 def register_vcs_handler(vcs, method):  # decorator

--- a/enderchest/cli.py
+++ b/enderchest/cli.py
@@ -6,8 +6,9 @@ import logging
 import os
 import sys
 from argparse import ArgumentParser, RawTextHelpFormatter
+from collections.abc import Iterable, Sequence
 from pathlib import Path
-from typing import Any, Iterable, Protocol, Sequence
+from typing import Any, Protocol
 
 from . import craft, gather, inventory, loggers, place, remote, uninstall
 from ._version import get_versions

--- a/enderchest/config.py
+++ b/enderchest/config.py
@@ -2,10 +2,11 @@
 
 import ast
 import datetime as dt
+from collections.abc import Iterable, Mapping, Sequence
 from configparser import ConfigParser, ParsingError
 from io import StringIO
 from pathlib import Path
-from typing import Any, Iterable, Mapping, Sequence
+from typing import Any
 
 from ._version import get_versions
 

--- a/enderchest/craft.py
+++ b/enderchest/craft.py
@@ -3,8 +3,8 @@
 import logging
 import re
 from collections import Counter
+from collections.abc import Callable, Iterable, Sequence
 from pathlib import Path
-from typing import Callable, Iterable, Sequence
 from urllib.parse import ParseResult
 
 from pathvalidate import is_valid_filename

--- a/enderchest/enderchest.py
+++ b/enderchest/enderchest.py
@@ -1,9 +1,10 @@
 """Specification and configuration of an EnderChest"""
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from socket import gethostname
-from typing import Any, Iterable
+from typing import Any
 from urllib.parse import ParseResult, urlparse
 
 from . import config as cfg

--- a/enderchest/filesystem.py
+++ b/enderchest/filesystem.py
@@ -1,8 +1,9 @@
 """Functionality for managing the EnderChest and shulker box config files and folders"""
 
+import itertools
 import os
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable
 
 from .loggers import INVENTORY_LOGGER
 
@@ -193,7 +194,9 @@ def minecraft_folders(search_path: Path) -> Iterable[Path]:
     This method does not check to make sure that those .minecraft folders
     contain valid minecraft instances, just that they exist
     """
-    return search_path.rglob(".minecraft")
+    return itertools.chain(
+        search_path.rglob(".minecraft"), search_path.rglob("minecraft")
+    )
 
 
 def links_into_enderchest(

--- a/enderchest/gather.py
+++ b/enderchest/gather.py
@@ -5,9 +5,10 @@ import json
 import logging
 import os
 import re
+from collections.abc import Iterable
 from configparser import ConfigParser, ParsingError
 from pathlib import Path
-from typing import Any, Iterable, TypedDict
+from typing import Any, TypedDict
 from urllib.parse import ParseResult
 
 from . import filesystem as fs

--- a/enderchest/inventory.py
+++ b/enderchest/inventory.py
@@ -1,8 +1,8 @@
 """Functionality for resolving EnderChest and shulker box states"""
 
 import logging
+from collections.abc import Iterable, Sequence
 from pathlib import Path
-from typing import Iterable, Sequence
 from urllib.parse import ParseResult
 
 from enderchest.sync import render_remote

--- a/enderchest/place.py
+++ b/enderchest/place.py
@@ -6,8 +6,8 @@ import json
 import logging
 import os
 from collections import defaultdict
+from collections.abc import Iterable, Sequence
 from pathlib import Path
-from typing import Iterable, Sequence
 
 from . import filesystem as fs
 from .inventory import load_ender_chest, load_ender_chest_instances, load_shulker_boxes

--- a/enderchest/remote.py
+++ b/enderchest/remote.py
@@ -1,9 +1,9 @@
 """Higher-level functionality around synchronizing with different EnderCherts"""
 
 import logging
+from collections.abc import Sequence
 from pathlib import Path
 from time import sleep
-from typing import Sequence
 from urllib.parse import ParseResult, urlparse
 
 from . import filesystem as fs

--- a/enderchest/shulker_box.py
+++ b/enderchest/shulker_box.py
@@ -3,8 +3,9 @@
 import fnmatch
 import os
 import re
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable, NamedTuple
+from typing import Any, NamedTuple
 
 import semantic_version as semver
 

--- a/enderchest/sync/__init__.py
+++ b/enderchest/sync/__init__.py
@@ -1,10 +1,10 @@
 """Low-level functionality for synchronizing across different machines"""
 
 import importlib
+from collections.abc import Collection, Generator
 from contextlib import contextmanager
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Collection, Generator
 from urllib.parse import ParseResult
 
 from ..loggers import SYNC_LOGGER

--- a/enderchest/sync/file.py
+++ b/enderchest/sync/file.py
@@ -5,8 +5,8 @@ import logging
 import os
 import shutil
 import stat
+from collections.abc import Callable, Collection
 from pathlib import Path
-from typing import Callable, Collection
 from urllib.parse import ParseResult
 
 from . import (

--- a/enderchest/sync/rsync.py
+++ b/enderchest/sync/rsync.py
@@ -5,8 +5,8 @@ import re
 import shutil
 import subprocess
 from collections import defaultdict
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable
 from urllib.parse import ParseResult, unquote
 
 from . import SYNC_LOGGER, get_default_netloc, uri_to_ssh

--- a/enderchest/sync/sftp.py
+++ b/enderchest/sync/sftp.py
@@ -3,9 +3,10 @@
 import os
 import posixpath
 import stat
+from collections.abc import Collection, Generator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Collection, Generator
+from typing import Any
 from urllib.parse import ParseResult, unquote
 from urllib.request import url2pathname
 

--- a/enderchest/sync/utils.py
+++ b/enderchest/sync/utils.py
@@ -6,9 +6,10 @@ import os
 import socket
 import stat
 from collections import defaultdict
+from collections.abc import Collection, Generator, Iterable
 from enum import Enum, auto
 from pathlib import Path
-from typing import Any, Collection, Generator, Iterable, Protocol, TypeVar
+from typing import Any, Protocol, TypeVar
 from urllib.parse import ParseResult, unquote
 from urllib.request import url2pathname
 

--- a/enderchest/test/conftest.py
+++ b/enderchest/test/conftest.py
@@ -35,7 +35,7 @@ def file_system(tmp_path) -> Generator[tuple[Path, Path], None, None]:
     minecraft_root = tmp_path / "minecraft"
     minecraft_root.mkdir(parents=True)
 
-    populate_instances_folder(minecraft_root / "instances")
+    populate_instances_folder(minecraft_root)
 
     home = tmp_path / "home"
     home.mkdir(parents=True)
@@ -103,7 +103,7 @@ def file_system(tmp_path) -> Generator[tuple[Path, Path], None, None]:
             minecraft_root
             / "instances"
             / "chest-boat"
-            / ".minecraft"
+            / "minecraft"
             / "mods"
             / "BME.jar"
         ): (mod_builds_folder / "BME_1.19_alpha.jar"),

--- a/enderchest/test/conftest.py
+++ b/enderchest/test/conftest.py
@@ -1,8 +1,8 @@
 """Useful setup / teardown fixtures"""
 
+from collections.abc import Generator
 from importlib.resources import as_file
 from pathlib import Path
-from typing import Generator
 
 import pytest
 

--- a/enderchest/test/mock_paramiko.py
+++ b/enderchest/test/mock_paramiko.py
@@ -3,10 +3,11 @@
 import json
 import os
 import shutil
+from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from importlib.resources import as_file
 from pathlib import Path
-from typing import Callable, Generator, NamedTuple
+from typing import NamedTuple
 from urllib.parse import ParseResult
 from urllib.request import url2pathname
 

--- a/enderchest/test/test_cli.py
+++ b/enderchest/test/test_cli.py
@@ -2,8 +2,8 @@
 
 import logging
 import os
+from collections.abc import Generator
 from pathlib import Path
-from typing import Generator
 
 import pytest
 

--- a/enderchest/test/test_craft.py
+++ b/enderchest/test/test_craft.py
@@ -795,7 +795,7 @@ class TestPromptByNumber:
   1. official (~/.minecraft)
   2. axolotl (instances/axolotl/.minecraft)
   3. bee (instances/bee/.minecraft)
-  4. Chest Boat (instances/chest-boat/.minecraft)"""
+  4. Chest Boat (instances/chest-boat/minecraft)"""
             )
             return utils.TESTING_INSTANCES
 
@@ -821,7 +821,7 @@ These are the instances that are currently registered:
   1. official (~/.minecraft)
   2. axolotl (instances/axolotl/.minecraft)
   3. bee (instances/bee/.minecraft)
-  4. Chest Boat (instances/chest-boat/.minecraft)""" in "\n".join(
+  4. Chest Boat (instances/chest-boat/minecraft)""" in "\n".join(
             record.msg for record in caplog.records
         )
 

--- a/enderchest/test/test_gather.py
+++ b/enderchest/test/test_gather.py
@@ -39,17 +39,20 @@ class TestGatherInstances:
         )
 
     @pytest.mark.parametrize(
-        "instance, idx",
+        "instance, idx, dot_root",
         (
-            ("axolotl", 1),
-            ("bee", 2),
-            ("chest-boat", 3),
+            ("axolotl", 1, True),
+            ("bee", 2, True),
+            ("chest-boat", 3, False),
         ),
     )
-    def test_mmc_instance_parsing(self, minecraft_root, instance, idx):
+    def test_mmc_instance_parsing(self, minecraft_root, instance, idx, dot_root):
         assert utils.normalize_instance(
             gather.gather_metadata_for_mmc_instance(
-                minecraft_root / "instances" / instance / ".minecraft"
+                minecraft_root
+                / "instances"
+                / instance
+                / (".minecraft" if dot_root else "minecraft")
             )
         ) == utils.normalize_instance(
             # we're not testing aliasing right now
@@ -403,14 +406,17 @@ class TestSymlinkAllowlistHandling:
             )
 
         utils.populate_mmc_instance_folder(
-            minecraft_root / "instances" / "talespin", "1.20", "Quilt", "talespin"
+            minecraft_root / "instances" / "talespin" / "minecraft",
+            "1.20",
+            "Quilt",
+            "talespin",
         )
 
         (
             minecraft_root
             / "instances"
             / "talespin"
-            / ".minecraft"
+            / "minecraft"
             / "allowed_symlinks.txt"
         ).write_text(
             "my_development_folder\n"
@@ -423,7 +429,7 @@ class TestSymlinkAllowlistHandling:
                 minecraft_root
                 / "instances"
                 / "talespin"
-                / ".minecraft"
+                / "minecraft"
                 / "allowed_symlinks.txt"
             )
             .read_text()
@@ -451,7 +457,7 @@ class TestSymlinkAllowlistHandling:
             minecraft_root
             / "instances"
             / "talespin"
-            / ".minecraft"
+            / "minecraft"
             / "allowed_symlinks.txt"
         ).read_text() == "my_development_folder\n"
 
@@ -493,7 +499,7 @@ class TestSymlinkAllowlistHandling:
             minecraft_root
             / "instances"
             / "talespin"
-            / ".minecraft"
+            / "minecraft"
             / "allowed_symlinks.txt"
         ).read_text() == f"my_development_folder\n{ender_chest_path}\n"
 

--- a/enderchest/test/test_place.py
+++ b/enderchest/test/test_place.py
@@ -38,9 +38,9 @@ class TestRglob:
         for instance in utils.TESTING_INSTANCES[1:]:
             expected.extend(
                 (
-                    instances_folder / instance.root.parent.name / ".minecraft",
-                    instances_folder / instance.root.parent.name / "instance.cfg",
-                    instances_folder / instance.root.parent.name / "mmc-pack.json",
+                    minecraft_root / instance.root,
+                    minecraft_root / instance.root.parent / "instance.cfg",
+                    minecraft_root / instance.root.parent / "mmc-pack.json",
                 )
             )
         expected.sort()
@@ -928,6 +928,8 @@ class TestMultiShulkerPlacing:
 
         assert (
             f'{os.path.join(instance, ".minecraft")} to {shulker_box}' in link_log
+        ) or (
+            f'{os.path.join(instance, "minecraft")} to {shulker_box}' in link_log
         ) is should_match
 
     @pytest.mark.parametrize("error_handling", ("ignore", "skip"))
@@ -1048,7 +1050,7 @@ class TestMultiShulkerPlacing:
         assert placements["Chest Boat"][Path("options.txt")] == ["1.19"]
 
         assert (
-            minecraft_root / "instances" / "chest-boat" / ".minecraft" / "options.txt"
+            minecraft_root / "instances" / "chest-boat" / "minecraft" / "options.txt"
         ).read_text() == "autoJump:true"
         assert not (home / ".minecraft" / "data" / "achievements.txt").exists()
 
@@ -1070,7 +1072,7 @@ class TestMultiShulkerPlacing:
         ).read_text() == "Spelled acheivements correctly!"
 
         assert not (
-            minecraft_root / "instances" / "chest-boat" / ".minecraft" / "options.txt"
+            minecraft_root / "instances" / "chest-boat" / "minecraft" / "options.txt"
         ).exists()
 
     def test_raise_on_invalid_error_handling_arg(self, home, minecraft_root, caplog):
@@ -1158,7 +1160,7 @@ not-this-chest
         assert "1.19" not in set(sum(placements["Chest Boat"].values(), []))
 
         assert not (
-            minecraft_root / "instances" / "chest-boat" / ".minecraft" / "options.txt"
+            minecraft_root / "instances" / "chest-boat" / "minecraft" / "options.txt"
         ).exists()
 
         assert (

--- a/enderchest/test/test_sync.py
+++ b/enderchest/test/test_sync.py
@@ -570,7 +570,7 @@ class TestFileSync:
 
     @pytest.mark.parametrize(
         "operation, mode",
-        itertools.product(("pull", "push"), ("immediate", "dry_run_first")),
+        list(itertools.product(("pull", "push"), ("immediate", "dry_run_first"))),
     )
     def test_sync_respects_exclude(
         self, minecraft_root, remote, caplog, operation, mode

--- a/enderchest/test/testing_files/enderchest.cfg
+++ b/enderchest/test/testing_files/enderchest.cfg
@@ -29,7 +29,7 @@ modloader = Forge
 groups = Modded
 
 [Chest Boat]
-root = instances/chest-boat/.minecraft
+root = instances/chest-boat/minecraft
 minecraft_version = 1.19.0
 modloader = Fabric Loader
 groups = Vanilla Plus

--- a/enderchest/test/utils.py
+++ b/enderchest/test/utils.py
@@ -194,34 +194,34 @@ def populate_mmc_instance_folder(
     name : str, optional
         The name of the instance (if different from the name of the folder)
     """
-    _set_up_minecraft_folder(instance_folder / ".minecraft", official=False)
+    _set_up_minecraft_folder(instance_folder, official=False)
     create_mmc_pack_file(
-        instance_folder, minecraft_version=minecraft_version, loader=loader
+        instance_folder.parent, minecraft_version=minecraft_version, loader=loader
     )
-    create_instance_cfg(instance_folder, name or instance_folder.name)
+    create_instance_cfg(instance_folder.parent, name or instance_folder.parent.name)
 
 
-def populate_instances_folder(instances_folder: Path) -> None:
+def populate_instances_folder(minecraft_root: Path) -> None:
     """Populate an MMC-style "instances" folder according to what's already in
     enderchest.cfg
 
     Parameters
     ----------
-    instances_folder : Path
-        The path of the instances folder
+    minecraft_root : Path
+        The parent of the instances folder
     """
-    instances_folder.mkdir(parents=True)
+    (minecraft_root / "instances").mkdir(parents=True)
     for instance_spec in TESTING_INSTANCES:
         if instance_spec.name == "official":
             continue
 
         populate_mmc_instance_folder(
-            instances_folder / instance_spec.root.parent.name,
+            minecraft_root / instance_spec.root,
             instance_spec.minecraft_versions[0],
             instance_spec.modloader,
         )
     with as_file(testing_files.INSTGROUPS) as instgroups:
-        shutil.copy(instgroups, instances_folder)
+        shutil.copy(instgroups, minecraft_root / "instances")
 
 
 def pre_populate_enderchest(

--- a/enderchest/test/utils.py
+++ b/enderchest/test/utils.py
@@ -2,9 +2,9 @@
 
 import json
 import shutil
+from collections.abc import Callable, Iterable
 from importlib.resources import as_file
 from pathlib import Path
-from typing import Callable, Iterable
 
 import pytest
 

--- a/enderchest/uninstall.py
+++ b/enderchest/uninstall.py
@@ -1,10 +1,9 @@
 """Functionality for copying all files into their instances"""
 
-import logging
 import os
 import shutil
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable
 
 from . import filesystem as fs
 from .enderchest import create_ender_chest

--- a/versioneer.py
+++ b/versioneer.py
@@ -310,8 +310,8 @@ import os
 import re
 import subprocess
 import sys
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable, Dict
 
 try:
     import tomli
@@ -411,8 +411,8 @@ class NotThisMethod(Exception):
 
 
 # these dictionaries contain VCS-specific tools
-LONG_VERSION_PY: Dict[str, str] = {}
-HANDLERS: Dict[str, Dict[str, Callable]] = {}
+LONG_VERSION_PY: dict[str, str] = {}
+HANDLERS: dict[str, dict[str, Callable]] = {}
 
 
 def register_vcs_handler(vcs, method):  # decorator


### PR DESCRIPTION
## Summary
<!--- One sentence summary of this PR. Can oftentimes just be a matter of linking
      to the issue number --->

Addresses #140

## List of Changes
<!--- List out the changes introduced by this PR, permalinking
      (read: with commit hash) to the commit, file or section of code where
      that change was implemented --->

* Updates `gather` command to search for folders named "minecraft" in addition to files named ".minecraft"
* Updates imports to pull various abstract base classes from [`collections.abc` instead of `typing`](https://docs.python.org/3/library/typing.html#aliases-to-other-abcs-in-collections-abc) (as the latter is deprecated)

## Tech Debt and Other Concerns
<!--- Use this section to call out anything in the code (including stuff you
      discovered outside of your contributions!) that you think may cause
      issues either now or further down the road. These will need to be spun
      off into issues before the PR is closed but shouldn't impede you opening
      the PR and starting the review process --->


<!--- Un-comment this section if this is still a work in progress. When doing
      so, please be sure to add (WIP), (Draft) or (DNM) in the PR title and
      open this PR as a draft

## To Do

--->


## Validation Performed
<!--- What did you do to ensure that this change is behaving as intended? This
should start with unit tests, but it's usually a good idea to try running
the code in a real setting. Include screenshots if you'd like, but make sure to
remove any personal information you won't want to share --->

Using this version of EnderChest, I ran the following command to "gather" an instance that had recently been created by PrismLauncher:

```bash
$ enderchest gather instance instances/NewInstance/
Could not parse instance name from /home/openbagtwo/minecraft/instances/NewInstance/instance.cfg
Gathered MMC-like Minecraft installation from instances/NewInstance/minecraft

Starting with Minecraft 1.20, Mojang by default no longer allows worlds
to load if they are or if they contain symbolic links.
Read more: https://help.minecraft.net/hc/en-us/articles/16165590199181
==> Would you like EnderChest to add /home/openbagtwo/minecraft/EnderChest to /home/openbagtwo/minecraft/instances/NewInstance/minecraft/allowed_symlinks.txt?
==> [Y/n] y
/home/openbagtwo/minecraft/instances/NewInstance/minecraft/allowed_symlinks.txt updated.
EnderChest configuration written to /home/openbagtwo/EnderChest/enderchest.cfg
```

After that, linking to that instance worked as expected.

## PR Type
<!--- Check all that apply --->
- [ ] This PR introduces a breaking change (will
  [require a bump in the minor version](https://semver.org/))
- [ ] The changes in this PR are high urgency and necessitate a hotfix or patch
  release (will require rebasing off of `release`)
- [ ] This is a release (staging) PR (maintainer use only)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.
      All bullets in this section are required to be checked off before the PR can
      be merged, but they don't need to be checked off before the PR is opened.
      If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] I have read [the contributor's guide](https://openbagtwo.github.io/EnderChest/dev/contrib/)
- [x] I have run `mkdocs serve` locally and ensured that all API docs and
  changes I have made to the static pages are rendering correctly, with all links
  working
- [x] All tech debt concerns have been resolved, documented as issues, or otherwise
  accepted
- [x] I agree to license my contribution to this project under
  [the GNU Public License v3](https://www.gnu.org/licenses/gpl-3.0.en.html)
  <!--- If you wish to use a different compatible license, please edit the above--->


<!--- Adapted from https://github.com/stevemao/github-issue-templates --->
